### PR TITLE
fix profile container getProfiles targeting wrong ID key

### DIFF
--- a/components/profile-container/profile-container.js
+++ b/components/profile-container/profile-container.js
@@ -38,10 +38,10 @@ export class ProfileContainer extends LitElement {
     return [...this.shadowRoot.querySelectorAll('profile-ui')]
       .filter((p) => !p.isPlaceholder && !isEmptyObject(p) && this.isValidSpeaker(p))
       .map((profileUI, index) => {
-        const { id, type } = profileUI.profile;
+        const { speakerId, type } = profileUI.profile;
 
         return {
-          speakerId: id,
+          speakerId,
           ordinal: index,
           speakerType: type,
         };


### PR DESCRIPTION
Fixing profile creation with missing speakerId

Resolves: 

Test URLs:
- Before: https://stage--ecc-milo--adobecom.hlx.page/
- After: https://speaker-id-fix--ecc-milo--adobecom.hlx.page/
