### PR TITLE
RSVP Default Fields

### DIFF
--- a/ecc/blocks/form-handler/controllers/registration-fields-component-controller.js
+++ b/ecc/blocks/form-handler/controllers/registration-fields-component-controller.js
@@ -2,9 +2,11 @@
 export function onSubmit(component, props) {
   if (component.closest('.fragment')?.classList.contains('hidden')) return;
 
+  const defaultFields = ['firstName', 'lastName', 'email', 'jobTitle'];
+
   const rsvpFormFields = {
-    visible: Array.from(component.querySelectorAll('sp-checkbox.check-appear[checked]')).map((f) => f.name),
-    required: Array.from(component.querySelectorAll('sp-checkbox.check-require[checked]')).map((f) => f.name),
+    visible: [...defaultFields, ...Array.from(component.querySelectorAll('sp-checkbox.check-appear[checked]')).map((f) => f.name)],
+    required: [...defaultFields, ...Array.from(component.querySelectorAll('sp-checkbox.check-require[checked]')).map((f) => f.name)],
   };
 
   props.payload = { ...props.payload, rsvpFormFields };


### PR DESCRIPTION
Pass the 4 default fields to all rsvp fields arrays. 

Resolves: [MWPW-147959](https://jira.corp.adobe.com/browse/MWPW-147959)

Test URLs:
- Before: https://dev--ecc-milo--adobecom.hlx.page/
- After: https://rsvp-fields-bug-fix--ecc-milo--adobecom.hlx.page/
