### PR TITLE
rsvp field lock and console.log cleanup

### DIFF
--- a/ecc/blocks/form-handler/controllers/registration-fields-component-controller.js
+++ b/ecc/blocks/form-handler/controllers/registration-fields-component-controller.js
@@ -31,6 +31,16 @@ export default function init(component, props) {
     });
   });
 
+  appearChecks.forEach((cb) => {
+    cb.addEventListener('change', () => {
+      if (!cb.checked) {
+        requireChecks.forEach((rc) => {
+          if (rc.name === cb.name) rc.checked = false;
+        });
+      }
+    });
+  });
+
   if (!eventData.rsvpFormFields) return;
 
   appearChecks.forEach((cb) => {

--- a/ecc/blocks/form-handler/controllers/registration-fields-component-controller.js
+++ b/ecc/blocks/form-handler/controllers/registration-fields-component-controller.js
@@ -21,6 +21,16 @@ export default function init(component, props) {
   const appearChecks = component.querySelectorAll('sp-checkbox.check-appear');
   const requireChecks = component.querySelectorAll('sp-checkbox.check-require');
 
+  requireChecks.forEach((cb) => {
+    cb.addEventListener('change', () => {
+      if (cb.checked) {
+        appearChecks.forEach((ac) => {
+          if (ac.name === cb.name) ac.checked = true;
+        });
+      }
+    });
+  });
+
   if (!eventData.rsvpFormFields) return;
 
   appearChecks.forEach((cb) => {

--- a/ecc/blocks/form-handler/form-handler.js
+++ b/ecc/blocks/form-handler/form-handler.js
@@ -647,14 +647,12 @@ async function buildECCForm(el) {
       }
 
       if (prop === 'payload') {
-        console.log('payload updated with: ', value);
         setPayloadCache(value);
         updateComponents(target);
         updateProfileContainer(target);
         initRequiredFieldsValidation(target);
       }
       if (prop === 'eventDataResp') {
-        console.log('response updated with: ', value);
         setResponseCache(value);
         updateCtas(target);
         updateDashboardLink(target);

--- a/ecc/scripts/event-apis.js
+++ b/ecc/scripts/event-apis.js
@@ -18,10 +18,7 @@ export async function getProfile() {
 
   const profile = await getUserProfile();
 
-  if (profile) {
-    console.log('Fetched user profile:', profile);
-    return profile;
-  }
+  if (profile) return profile;
 
   window.lana?.log('Failed to get user profile data.');
   return {};


### PR DESCRIPTION
RSVP fields required box check will automatically check appear too
cleaned up some console.logs

Test URLs:
- Before: https://stage--ecc-milo--adobecom.hlx.page/
- After: https://dev--ecc-milo--adobecom.hlx.page/
