### PR TITLE
Sponsor fetch for ECC from repopulation

### DIFF
--- a/ecc/blocks/event-format-component/event-format-component.js
+++ b/ecc/blocks/event-format-component/event-format-component.js
@@ -32,15 +32,11 @@ async function decorateSeriesSelect(column) {
   column.innerHTML = '';
   column.append(seriesSelectWrapper);
 
-  let series = await getSeries();
-  // if (!series) return;
+  const series = await getSeries();
   if (!series) {
-    series = [
-      {
-        seriesId: 'b75765b5-ceba-484c-9afc-c96955afabfb',
-        seriesName: 'Create Now Series (test)',
-      },
-    ];
+    select.pending = false;
+    select.disabled = true;
+    return;
   }
 
   Object.values(series).forEach((val) => {

--- a/ecc/blocks/event-format-component/event-format-component.js
+++ b/ecc/blocks/event-format-component/event-format-component.js
@@ -1,6 +1,5 @@
 import { LIBS } from '../../scripts/scripts.js';
 import { generateToolTip } from '../../scripts/utils.js';
-import { getSeries } from '../../scripts/esp-controller.js';
 
 const { createTag } = await import(`${LIBS}/utils/utils.js`);
 
@@ -31,20 +30,6 @@ async function decorateSeriesSelect(column) {
 
   column.innerHTML = '';
   column.append(seriesSelectWrapper);
-
-  const series = await getSeries();
-  if (!series) {
-    select.pending = false;
-    select.disabled = true;
-    return;
-  }
-
-  Object.values(series).forEach((val) => {
-    const opt = createTag('sp-menu-item', { value: val.seriesId }, val.seriesName);
-    select.append(opt);
-  });
-
-  select.pending = false;
 }
 
 function decorateTimeZoneSelect(column) {

--- a/ecc/blocks/form-handler/controllers/event-format-component-controller.js
+++ b/ecc/blocks/form-handler/controllers/event-format-component-controller.js
@@ -1,4 +1,5 @@
 /* eslint-disable no-unused-vars */
+import { getSeries } from '../../../scripts/esp-controller.js';
 import { MILO_CONFIG, LIBS } from '../../../scripts/scripts.js';
 import { changeInputValue } from '../../../scripts/utils.js';
 
@@ -74,10 +75,30 @@ export async function onUpdate(component, props) {
   }
 }
 
+async function populateSeriesOptions(component) {
+  const seriesSelect = component.querySelector('#series-select-input');
+  if (!seriesSelect) return;
+
+  const series = await getSeries();
+  if (!series) {
+    seriesSelect.pending = false;
+    seriesSelect.disabled = true;
+    return;
+  }
+
+  Object.values(series).forEach((val) => {
+    const opt = createTag('sp-menu-item', { value: val.seriesId }, val.seriesName);
+    seriesSelect.append(opt);
+  });
+
+  seriesSelect.pending = false;
+}
+
 export default function init(component, props) {
   const eventData = props.eventDataResp;
   prepopulateTimeZone(component);
   initStepLock(component);
+  populateSeriesOptions(component);
 
   const {
     cloudType,

--- a/ecc/blocks/form-handler/controllers/event-format-component-controller.js
+++ b/ecc/blocks/form-handler/controllers/event-format-component-controller.js
@@ -99,7 +99,7 @@ export default function init(component, props) {
       const toastArea = props.el.querySelector('.toast-area');
       if (!toastArea) return;
 
-      const toast = createTag('sp-toast', { open: true }, 'Series ID is taking longer than usual to load. Please check if the Adobe corp. VPN is connected.', { parent: toastArea });
+      const toast = createTag('sp-toast', { open: true, timeout: 8000 }, 'Series ID is taking longer than usual to load. Please check if the Adobe corp. VPN is connected.', { parent: toastArea });
       toast.addEventListener('close', () => {
         toast.remove();
       });

--- a/ecc/blocks/form-handler/controllers/event-format-component-controller.js
+++ b/ecc/blocks/form-handler/controllers/event-format-component-controller.js
@@ -1,6 +1,8 @@
 /* eslint-disable no-unused-vars */
-import { MILO_CONFIG } from '../../../scripts/scripts.js';
+import { MILO_CONFIG, LIBS } from '../../../scripts/scripts.js';
 import { changeInputValue } from '../../../scripts/utils.js';
+
+const { createTag } = await import(`${LIBS}/utils/utils.js`);
 
 function prepopulateTimeZone(component) {
   const currentTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
@@ -89,6 +91,20 @@ export default function init(component, props) {
     changeInputValue(component.querySelector('#rsvp-required-check'), 'checked', rsvpRequired || 0);
     component.classList.add('prefilled');
   }
+
+  setTimeout(() => {
+    const seriesSelect = component.querySelector('#series-select-input');
+
+    if (seriesSelect.pending || seriesSelect.disabled) {
+      const toastArea = props.el.querySelector('.toast-area');
+      if (!toastArea) return;
+
+      const toast = createTag('sp-toast', { open: true }, 'Series ID is taking longer than usual to load. Please check if the Adobe corp. VPN is connected.', { parent: toastArea });
+      toast.addEventListener('close', () => {
+        toast.remove();
+      });
+    }
+  }, 5000);
 }
 
 function getTemplateId(bu) {

--- a/ecc/blocks/form-handler/controllers/event-format-component-controller.js
+++ b/ecc/blocks/form-handler/controllers/event-format-component-controller.js
@@ -79,19 +79,20 @@ async function populateSeriesOptions(component) {
   const seriesSelect = component.querySelector('#series-select-input');
   if (!seriesSelect) return;
 
-  const series = await getSeries();
-  if (!series) {
+  getSeries().then((series) => {
+    if (!series) {
+      seriesSelect.pending = false;
+      seriesSelect.disabled = true;
+      return;
+    }
+
+    Object.values(series).forEach((val) => {
+      const opt = createTag('sp-menu-item', { value: val.seriesId }, val.seriesName);
+      seriesSelect.append(opt);
+    });
+
     seriesSelect.pending = false;
-    seriesSelect.disabled = true;
-    return;
-  }
-
-  Object.values(series).forEach((val) => {
-    const opt = createTag('sp-menu-item', { value: val.seriesId }, val.seriesName);
-    seriesSelect.append(opt);
   });
-
-  seriesSelect.pending = false;
 }
 
 export default function init(component, props) {

--- a/ecc/blocks/form-handler/controllers/event-format-component-controller.js
+++ b/ecc/blocks/form-handler/controllers/event-format-component-controller.js
@@ -79,7 +79,7 @@ async function populateSeriesOptions(component) {
   const seriesSelect = component.querySelector('#series-select-input');
   if (!seriesSelect) return;
 
-  const series = getSeries();
+  const series = await getSeries();
   if (!series) {
     seriesSelect.pending = false;
     seriesSelect.disabled = true;

--- a/ecc/blocks/form-handler/controllers/event-format-component-controller.js
+++ b/ecc/blocks/form-handler/controllers/event-format-component-controller.js
@@ -75,7 +75,7 @@ export async function onUpdate(component, props) {
   }
 }
 
-function populateSeriesOptions(component) {
+async function populateSeriesOptions(component) {
   const seriesSelect = component.querySelector('#series-select-input');
   if (!seriesSelect) return;
 

--- a/ecc/blocks/form-handler/controllers/event-format-component-controller.js
+++ b/ecc/blocks/form-handler/controllers/event-format-component-controller.js
@@ -79,27 +79,26 @@ async function populateSeriesOptions(component) {
   const seriesSelect = component.querySelector('#series-select-input');
   if (!seriesSelect) return;
 
-  getSeries().then((series) => {
-    if (!series) {
-      seriesSelect.pending = false;
-      seriesSelect.disabled = true;
-      return;
-    }
-
-    Object.values(series).forEach((val) => {
-      const opt = createTag('sp-menu-item', { value: val.seriesId }, val.seriesName);
-      seriesSelect.append(opt);
-    });
-
+  const series = getSeries();
+  if (!series) {
     seriesSelect.pending = false;
+    seriesSelect.disabled = true;
+    return;
+  }
+
+  Object.values(series).forEach((val) => {
+    const opt = createTag('sp-menu-item', { value: val.seriesId }, val.seriesName);
+    seriesSelect.append(opt);
   });
+
+  seriesSelect.pending = false;
 }
 
-export default function init(component, props) {
+export default async function init(component, props) {
   const eventData = props.eventDataResp;
   prepopulateTimeZone(component);
   initStepLock(component);
-  populateSeriesOptions(component);
+  await populateSeriesOptions(component);
 
   const {
     cloudType,

--- a/ecc/blocks/form-handler/controllers/event-format-component-controller.js
+++ b/ecc/blocks/form-handler/controllers/event-format-component-controller.js
@@ -75,7 +75,7 @@ export async function onUpdate(component, props) {
   }
 }
 
-async function populateSeriesOptions(component) {
+function populateSeriesOptions(component) {
   const seriesSelect = component.querySelector('#series-select-input');
   if (!seriesSelect) return;
 

--- a/ecc/blocks/form-handler/controllers/event-partners-component-controller.js
+++ b/ecc/blocks/form-handler/controllers/event-partners-component-controller.js
@@ -60,12 +60,19 @@ export default async function init(component, props) {
 
         if (partnerData) {
           let photo;
-          const { name, link } = partnerData;
+          const { name, link, sponsorId } = partnerData;
           if (partnerData.image) {
             photo = { ...partnerData.image, url: partnerData.image.imageUrl };
           }
 
-          return { name, link, isValidPartner: true, photo, index };
+          return {
+            name,
+            link,
+            sponsorId,
+            isValidPartner: true,
+            photo,
+            index,
+          };
         }
       }
       return { index, isValidPartner: false };

--- a/ecc/blocks/form-handler/controllers/event-partners-component-controller.js
+++ b/ecc/blocks/form-handler/controllers/event-partners-component-controller.js
@@ -47,8 +47,8 @@ export async function onSubmit(component, props) {
           // do nothing
         } else {
           const updatableData = {
-            name: partner.name,
-            link: partner.link,
+            sponsorId,
+            sponsorType,
           };
           const resp = await updateSponsorInEvent(updatableData, partner.sponsorId, eventId);
           if (!resp || resp.errors) {

--- a/ecc/blocks/form-handler/controllers/event-partners-component-controller.js
+++ b/ecc/blocks/form-handler/controllers/event-partners-component-controller.js
@@ -7,11 +7,11 @@ export async function onSubmit(component, props) {
 
   const partnerVisible = component.querySelector('#partners-visible')?.checked;
   const partnerSelectorGroup = component.querySelector('partner-selector-group');
-  const { eventId, sponsors } = getFilteredCachedResponse();
+  const { eventId } = getFilteredCachedResponse();
 
   if (partnerSelectorGroup && eventId) {
-    if (sponsors) {
-      const responses = await Promise.all(sponsors.map(async (sponsor) => {
+    if (props.eventDataResp?.sponsors) {
+      const responses = await Promise.all(props.eventDataResp?.sponsors.map(async (sponsor) => {
         if (sponsor.sponsorType === 'Partner') {
           const resp = await removeSponsorFromEvent(sponsor.sponsorId, eventId);
           if (resp && !resp.errors) {

--- a/ecc/blocks/form-handler/controllers/event-partners-component-controller.js
+++ b/ecc/blocks/form-handler/controllers/event-partners-component-controller.js
@@ -49,14 +49,14 @@ export default async function init(component, props) {
             photo = { ...partnerData.image, url: partnerData.image.imageUrl };
           }
 
-          return { name, link, isValid: true, photo, index };
+          return { name, link, isValidPartner: true, photo, index };
         }
       }
-      return { index, isValid: false };
+      return { index, isValidPartner: false };
     }));
 
     const filteredPartners = partners
-      .filter((partner) => partner.isValid)
+      .filter((partner) => partner.isValidPartner)
       .sort((a, b) => a.index - b.index)
       .map(({ name, link, photo }) => ({ name, link, photo }));
 

--- a/ecc/blocks/form-handler/controllers/event-partners-component-controller.js
+++ b/ecc/blocks/form-handler/controllers/event-partners-component-controller.js
@@ -46,7 +46,11 @@ export async function onSubmit(component, props) {
         } else if (partner.hasUnsavedChanges) {
           // do nothing
         } else {
-          const resp = await updateSponsorInEvent(partner, partner.sponsorId, eventId);
+          const updatableData = {
+            name: partner.name,
+            link: partner.link,
+          };
+          const resp = await updateSponsorInEvent(updatableData, partner.sponsorId, eventId);
           if (!resp || resp.errors) {
             return;
           }

--- a/ecc/blocks/form-handler/controllers/event-partners-component-controller.js
+++ b/ecc/blocks/form-handler/controllers/event-partners-component-controller.js
@@ -14,6 +14,7 @@ export async function onSubmit(component, props) {
     const partners = partnerSelectorGroup.getSavedPartners();
     await partners.reduce(async (promise, partner) => {
       await promise;
+
       const { sponsorId, sponsorType } = partner;
 
       if (!props.eventDataResp.sponsors) {
@@ -21,12 +22,13 @@ export async function onSubmit(component, props) {
           sponsorId,
           sponsorType,
         }, eventId);
+
         if (!resp || resp.errors) {
           return;
         }
 
         props.eventDataResp = { ...props.eventDataResp, ...resp };
-      } else if (props.eventDataResp.sponsors) {
+      } else {
         const existingPartner = props.eventDataResp.sponsors.find((sponsor) => {
           const idMatch = sponsor.sponsorId === sponsorId;
           const typeMatch = sponsor.sponsorType === sponsorType;
@@ -38,19 +40,21 @@ export async function onSubmit(component, props) {
             sponsorId,
             sponsorType,
           }, eventId);
+
           if (!resp || resp.errors) {
             return;
           }
 
           props.eventDataResp = { ...props.eventDataResp, ...resp };
         } else if (partner.hasUnsavedChanges) {
-          // do nothing
+          // If there are unsaved changes, do nothing
         } else {
           const updatableData = {
             sponsorId,
             sponsorType,
           };
           const resp = await updateSponsorInEvent(updatableData, partner.sponsorId, eventId);
+
           if (!resp || resp.errors) {
             return;
           }

--- a/ecc/blocks/form-handler/data-handler.js
+++ b/ecc/blocks/form-handler/data-handler.js
@@ -39,7 +39,6 @@ const wl = [
   'creationTime',
   'modificationTime',
   'detailPagePath',
-  'sponsors',
 ];
 
 function isValidAttribute(attr) {

--- a/ecc/blocks/form-handler/data-handler.js
+++ b/ecc/blocks/form-handler/data-handler.js
@@ -39,6 +39,7 @@ const wl = [
   'creationTime',
   'modificationTime',
   'detailPagePath',
+  'sponsors',
 ];
 
 function isValidAttribute(attr) {

--- a/ecc/blocks/form-handler/form-handler.css
+++ b/ecc/blocks/form-handler/form-handler.css
@@ -39,7 +39,7 @@
   display: flex;
   flex-direction: column;
   justify-content: center;
-  min-height: calc(100vh - 72px - (var(--feds-height-nav) * 2));
+  min-height: calc(100vh - 203px);
 }
 
 .form-handler .side-menu h3 {
@@ -130,6 +130,12 @@
 
 .form-handler .main-frame {
   flex-grow: 1;
+  min-height: 100%;
+}
+
+.form-handler .main-frame sp-theme {
+  min-height: 100%;
+  position: relative;
 }
 
 .form-handler .main-frame .section .content {
@@ -349,13 +355,13 @@
 }
 
 .form-handler .toast-area {
-  position: sticky;
-  left: 100%;
-  bottom: 88px;
-  margin-bottom: 16px;
+  position: absolute;
+  right: 0;
+  bottom: 40px;
   display: flex;
   flex-direction: column;
   align-items: flex-end;
+  justify-content: flex-end;
   gap: 16px;
 }
 

--- a/ecc/blocks/form-handler/form-handler.css
+++ b/ecc/blocks/form-handler/form-handler.css
@@ -1,7 +1,6 @@
 .form-handler {
   display: block;
   padding: 0 40px;
-  transition: opacity 0.3s;
 
   --mod-textfield-icon-size-invalid: 0;
   --stroke-color-divider: #6E6E6E;
@@ -24,7 +23,6 @@
 
 .form-handler.disabled .main-frame,
 .form-handler.disabled .form-handler-ctas-panel {
-  opacity: 0.7;
   pointer-events: none;
 }
 

--- a/ecc/blocks/form-handler/form-handler.css
+++ b/ecc/blocks/form-handler/form-handler.css
@@ -1,6 +1,7 @@
 .form-handler {
   display: block;
   padding: 0 40px;
+  transition: opacity 0.3s;
 
   --mod-textfield-icon-size-invalid: 0;
   --stroke-color-divider: #6E6E6E;
@@ -19,6 +20,11 @@
 
 .form-handler.show-error {
   --mod-textfield-icon-size-invalid: 16px;
+}
+
+.form-handler.disabled {
+  opacity: 0.7;
+  pointer-events: none;
 }
 
 .form-handler .side-menu button {

--- a/ecc/blocks/form-handler/form-handler.css
+++ b/ecc/blocks/form-handler/form-handler.css
@@ -39,7 +39,7 @@
   display: flex;
   flex-direction: column;
   justify-content: center;
-  min-height: 50vh;
+  min-height: calc(100vh - 72px - (var(--feds-height-nav) * 2));
 }
 
 .form-handler .side-menu h3 {

--- a/ecc/blocks/form-handler/form-handler.css
+++ b/ecc/blocks/form-handler/form-handler.css
@@ -142,6 +142,9 @@
 .form-handler .main-frame sp-theme {
   min-height: 100%;
   position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
 }
 
 .form-handler .main-frame .section .content {
@@ -361,9 +364,10 @@
 }
 
 .form-handler .toast-area {
-  position: absolute;
+  position: sticky;
   right: 0;
-  bottom: 40px;
+  bottom: 88px;
+  margin-bottom: 16px;
   display: flex;
   flex-direction: column;
   align-items: flex-end;

--- a/ecc/blocks/form-handler/form-handler.css
+++ b/ecc/blocks/form-handler/form-handler.css
@@ -22,7 +22,8 @@
   --mod-textfield-icon-size-invalid: 16px;
 }
 
-.form-handler.disabled {
+.form-handler.disabled .main-frame,
+.form-handler.disabled .form-handler-ctas-panel {
   opacity: 0.7;
   pointer-events: none;
 }

--- a/ecc/blocks/form-handler/form-handler.js
+++ b/ecc/blocks/form-handler/form-handler.js
@@ -152,12 +152,13 @@ async function initComponents(props) {
         const toastArea = props.el.querySelector('.toast-area');
         if (!toastArea) return;
 
-        const toast = createTag('sp-toast', { open: true, timeout: 16000 }, 'Event data is taking longer than usual to load. Please check if the Adobe corp. VPN is connected or if the eventId URL Param is valid.', { parent: toastArea });
+        const toast = createTag('sp-toast', { open: true, timeout: 10000 }, 'Event data is taking longer than usual to load. Please check if the Adobe corp. VPN is connected or if the eventId URL Param is valid.', { parent: toastArea });
         toast.addEventListener('close', () => {
           toast.remove();
         });
       }
     }, 5000);
+
     props.el.classList.add('disabled');
     const eventData = await getEvent(eventId);
     props.eventDataResp = { ...props.eventDataResp, ...eventData };

--- a/ecc/blocks/form-handler/form-handler.js
+++ b/ecc/blocks/form-handler/form-handler.js
@@ -152,7 +152,7 @@ async function initComponents(props) {
         const toastArea = props.el.querySelector('.toast-area');
         if (!toastArea) return;
 
-        const toast = createTag('sp-toast', { open: true, timeout: 8000 }, 'Event data is taking longer than usual to load. Please check if the Adobe corp. VPN is connected or if the eventId URL Param is valid.', { parent: toastArea });
+        const toast = createTag('sp-toast', { open: true, timeout: 16000 }, 'Event data is taking longer than usual to load. Please check if the Adobe corp. VPN is connected or if the eventId URL Param is valid.', { parent: toastArea });
         toast.addEventListener('close', () => {
           toast.remove();
         });

--- a/ecc/blocks/form-handler/form-handler.js
+++ b/ecc/blocks/form-handler/form-handler.js
@@ -1,5 +1,5 @@
 import { LIBS, MILO_CONFIG } from '../../scripts/scripts.js';
-import { getIcon, buildNoAccessScreen, yieldToMain, generateToolTip, camelToSentenceCase, buildSPToast } from '../../scripts/utils.js';
+import { getIcon, buildNoAccessScreen, yieldToMain, generateToolTip, camelToSentenceCase } from '../../scripts/utils.js';
 import {
   createEvent,
   updateEvent,

--- a/ecc/blocks/form-handler/form-handler.js
+++ b/ecc/blocks/form-handler/form-handler.js
@@ -270,6 +270,12 @@ async function saveEvent(props, options = { toPublish: false }) {
       getJoinedData(),
     );
     props.eventDataResp = { ...props.eventDataResp, ...resp };
+
+    const toastArea = props.el.querySelector('.toast-area');
+    const toast = createTag('sp-toast', { open: true, timeout: 8000 }, 'Form saved', { parent: toastArea });
+    toast.addEventListener('close', () => {
+      toast.remove();
+    });
   } else if (options.toPublish) {
     resp = await publishEvent(
       getFilteredCachedResponse().eventId,

--- a/ecc/blocks/form-handler/form-handler.js
+++ b/ecc/blocks/form-handler/form-handler.js
@@ -270,12 +270,6 @@ async function saveEvent(props, options = { toPublish: false }) {
       getJoinedData(),
     );
     props.eventDataResp = { ...props.eventDataResp, ...resp };
-
-    const toastArea = props.el.querySelector('.toast-area');
-    const toast = createTag('sp-toast', { open: true, timeout: 6000, variant: 'positive' }, 'Form saved', { parent: toastArea });
-    toast.addEventListener('close', () => {
-      toast.remove();
-    });
   } else if (options.toPublish) {
     resp = await publishEvent(
       getFilteredCachedResponse().eventId,

--- a/ecc/blocks/form-handler/form-handler.js
+++ b/ecc/blocks/form-handler/form-handler.js
@@ -681,9 +681,9 @@ async function buildECCForm(el) {
   });
 
   initFormCtas(proxyProps);
+  initNavigation(proxyProps);
   await initComponents(proxyProps);
   initRepeaters(proxyProps);
-  initNavigation(proxyProps);
   updateRequiredFields(proxyProps);
   enableSideNavForEditFlow(proxyProps);
   initDeepLink(proxyProps);

--- a/ecc/blocks/form-handler/form-handler.js
+++ b/ecc/blocks/form-handler/form-handler.js
@@ -68,13 +68,7 @@ const SPECTRUM_COMPONENTS = [
 function buildErrorMessage(props, resp) {
   if (!resp) return;
 
-  let toastArea = props.el.querySelector('.toast-area');
-
-  if (!toastArea) {
-    const spTheme = props.el.querySelector('sp-theme');
-    if (!spTheme) return;
-    toastArea = createTag('div', { class: 'toast-area' }, '', { parent: spTheme });
-  }
+  const toastArea = props.el.querySelector('.toast-area');
 
   if (resp.errors) {
     const messages = [];
@@ -249,6 +243,8 @@ function decorateForm(el) {
       });
     }
   });
+
+  createTag('div', { class: 'toast-area' }, '', { parent: app });
 
   form.addEventListener('submit', (e) => {
     e.preventDefault();

--- a/ecc/blocks/form-handler/form-handler.js
+++ b/ecc/blocks/form-handler/form-handler.js
@@ -147,8 +147,21 @@ async function initComponents(props) {
   const eventId = urlParams.get('eventId');
 
   if (eventId) {
+    setTimeout(() => {
+      if (!props.eventDataResp.eventId) {
+        const toastArea = props.el.querySelector('.toast-area');
+        if (!toastArea) return;
+
+        const toast = createTag('sp-toast', { open: true, timeout: 8000 }, 'Event data is taking longer than usual to load. Please check if the Adobe corp. VPN is connected or if the eventId URL Param is valid.', { parent: toastArea });
+        toast.addEventListener('close', () => {
+          toast.remove();
+        });
+      }
+    }, 5000);
+    props.el.classList.add('disabled');
     const eventData = await getEvent(eventId);
     props.eventDataResp = { ...props.eventDataResp, ...eventData };
+    props.el.classList.remove('disabled');
   }
 
   const componentPromises = VANILLA_COMPONENTS.map(async (comp) => {

--- a/ecc/blocks/form-handler/form-handler.js
+++ b/ecc/blocks/form-handler/form-handler.js
@@ -272,7 +272,7 @@ async function saveEvent(props, options = { toPublish: false }) {
     props.eventDataResp = { ...props.eventDataResp, ...resp };
 
     const toastArea = props.el.querySelector('.toast-area');
-    const toast = createTag('sp-toast', { open: true, timeout: 8000 }, 'Form saved', { parent: toastArea });
+    const toast = createTag('sp-toast', { open: true, timeout: 6000, variant: 'positive' }, 'Form saved', { parent: toastArea });
     toast.addEventListener('close', () => {
       toast.remove();
     });

--- a/ecc/blocks/form-handler/form-handler.js
+++ b/ecc/blocks/form-handler/form-handler.js
@@ -418,7 +418,6 @@ function navigateForm(props, stepIndex) {
 
 function initFormCtas(props) {
   const ctaRow = props.el.querySelector(':scope > div:last-of-type');
-  const frags = props.el.querySelectorAll('.fragment');
   decorateButtons(ctaRow, 'button-l');
   const ctas = ctaRow.querySelectorAll('a');
 

--- a/ecc/blocks/form-handler/form-handler.js
+++ b/ecc/blocks/form-handler/form-handler.js
@@ -1,5 +1,5 @@
 import { LIBS, MILO_CONFIG } from '../../scripts/scripts.js';
-import { getIcon, buildNoAccessScreen, yieldToMain, generateToolTip, camelToSentenceCase } from '../../scripts/utils.js';
+import { getIcon, buildNoAccessScreen, yieldToMain, generateToolTip, camelToSentenceCase, buildSPToast } from '../../scripts/utils.js';
 import {
   createEvent,
   updateEvent,

--- a/ecc/blocks/form-handler/form-handler.js
+++ b/ecc/blocks/form-handler/form-handler.js
@@ -210,8 +210,8 @@ function decorateForm(el) {
   }
 
   formDivs.forEach((formDiv) => {
-    formDiv.parentElement.replaceChild(app, formDiv);
-    form.append(formDiv);
+    formDiv.parentElement.parentElement.replaceChild(app, formDiv.parentElement);
+    form.append(formDiv.parentElement);
   });
 
   const cols = el.querySelectorAll(':scope > div:first-of-type > div');

--- a/ecc/components/image-dropzone/image-dropzone.js
+++ b/ecc/components/image-dropzone/image-dropzone.js
@@ -50,6 +50,8 @@ export class ImageDropzone extends LitElement {
       this.setFile(files);
       this.handleImage();
     }
+
+    this.dispatchEvent(new CustomEvent('image-change', { detail: { file: this.file } }));
   }
 
   handleDragover(e) {

--- a/ecc/components/partner-selector-group/partner-selector-group.js
+++ b/ecc/components/partner-selector-group/partner-selector-group.js
@@ -34,9 +34,10 @@ export default class PartnerSelectorGroup extends LitElement {
 
   getSavedPartners() {
     return this.partners.filter((p) => p.sponsorId).map((partner) => {
-      const { sponsorId, name, link } = partner;
+      const { sponsorId, name, link, hasUnsavedChanges } = partner;
 
       const data = {
+        hasUnsavedChanges,
         sponsorId,
         name,
         link,

--- a/ecc/components/partner-selector/partner-selector.js
+++ b/ecc/components/partner-selector/partner-selector.js
@@ -25,17 +25,19 @@ export default class PartnerSelector extends LitElement {
 
   firstUpdated() {
     this.imageDropzone = this.shadowRoot.querySelector('image-dropzone');
+    this.imageDropzone.handleImage = () => {
+      this.hasUnsavedChange = true;
+    };
     this.checkValidity();
   }
 
   updateValue(key, value) {
     this.hasUnsavedChange = true;
-    const imageDropzone = this.shadowRoot.querySelector('image-dropzone');
     const saveButton = this.shadowRoot.querySelector('.save-partner-button');
     if (saveButton) saveButton.textContent = 'Save Partner';
 
     this.partner = { ...this.partner, [key]: value };
-    this.partner.photo = imageDropzone?.file || null;
+    this.partner.photo = this.imageDropzone?.file || null;
 
     this.dispatchEvent(new CustomEvent('update-partner', {
       detail: { partner: this.partner },
@@ -49,7 +51,6 @@ export default class PartnerSelector extends LitElement {
   }
 
   async savePartner(e) {
-    const imageDropzone = this.shadowRoot.querySelector('image-dropzone');
     const saveButton = e.target;
     let respJson;
 
@@ -67,7 +68,7 @@ export default class PartnerSelector extends LitElement {
 
     if (respJson.sponsorId) {
       this.partner.sponsorId = respJson.sponsorId;
-      const file = imageDropzone?.getFile();
+      const file = this.imageDropzone?.getFile();
 
       if (file && (file instanceof File)) {
         const sponsorData = await uploadImage(file, {

--- a/ecc/components/partner-selector/partner-selector.js
+++ b/ecc/components/partner-selector/partner-selector.js
@@ -32,7 +32,7 @@ export default class PartnerSelector extends LitElement {
     this.partner = { ...this.partner, [key]: value };
     const imageDropzone = this.shadowRoot.querySelector('image-dropzone');
     this.partner.photo = imageDropzone?.file || null;
-    this.checkValidity();
+    // this.checkValidity();
     this.dispatchEvent(new CustomEvent('update-partner', {
       detail: { partner: this.partner },
       bubbles: true,
@@ -110,7 +110,7 @@ export default class PartnerSelector extends LitElement {
         </div>
       </div>
       <div class="action-area">
-        <sp-button variant="primary" .disabled=${!this.partner.isValid} class="save-partner-button" @click=${this.savePartner}>Save Partner</sp-button>
+        <sp-button variant="primary" ?disabled=${!this.checkValidity()} class="save-partner-button" @click=${this.savePartner}>Save Partner</sp-button>
         <slot name="delete-btn"></slot>
         </div>
       </fieldset>

--- a/ecc/components/partner-selector/partner-selector.js
+++ b/ecc/components/partner-selector/partner-selector.js
@@ -18,6 +18,7 @@ export default class PartnerSelector extends LitElement {
       name: '',
       link: '',
     };
+    this.hasUnsavedChange = false;
   }
 
   static styles = style;
@@ -28,6 +29,7 @@ export default class PartnerSelector extends LitElement {
   }
 
   updateValue(key, value) {
+    this.hasUnsavedChange = true;
     const imageDropzone = this.shadowRoot.querySelector('image-dropzone');
     const saveButton = this.shadowRoot.querySelector('.save-partner-button');
     if (saveButton) saveButton.textContent = 'Save Partner';
@@ -77,7 +79,7 @@ export default class PartnerSelector extends LitElement {
         if (sponsorData) {
           this.partner.modificationTime = sponsorData.modificationTime;
           if (saveButton) {
-            saveButton.disabled = true;
+            this.hasUnsavedChange = false;
             saveButton.textContent = 'Saved';
           }
         }
@@ -114,7 +116,7 @@ export default class PartnerSelector extends LitElement {
         </div>
       </div>
       <div class="action-area">
-        <sp-button variant="primary" ?disabled=${!this.checkValidity()} class="save-partner-button" @click=${this.savePartner}>Save Partner</sp-button>
+        <sp-button variant="primary" ?disabled=${!this.checkValidity() || !this.hasUnsavedChange} class="save-partner-button" @click=${this.savePartner}>Save Partner</sp-button>
         <slot name="delete-btn"></slot>
         </div>
       </fieldset>

--- a/ecc/components/partner-selector/partner-selector.js
+++ b/ecc/components/partner-selector/partner-selector.js
@@ -10,6 +10,7 @@ export default class PartnerSelector extends LitElement {
     partner: { type: Object },
     fieldLabels: { type: Object },
     seriesId: { type: String },
+    hasUnsavedChange: { type: Boolean },
   };
 
   constructor() {

--- a/ecc/components/partner-selector/partner-selector.js
+++ b/ecc/components/partner-selector/partner-selector.js
@@ -14,8 +14,7 @@ export default class PartnerSelector extends LitElement {
 
   constructor() {
     super();
-    this.partner = { ...this.partner, isValid: true } || {
-      isValid: false,
+    this.partner = this.partner || {
       name: '',
       link: '',
     };
@@ -41,8 +40,7 @@ export default class PartnerSelector extends LitElement {
   }
 
   checkValidity() {
-    this.partner.isValid = this.partner.name?.length >= 3 && this.partner.link?.match(LINK_REGEX);
-    this.requestUpdate();
+    return this.partner.name?.length >= 3 && this.partner.link?.match(LINK_REGEX);
   }
 
   async savePartner(e) {

--- a/ecc/components/partner-selector/partner-selector.js
+++ b/ecc/components/partner-selector/partner-selector.js
@@ -10,7 +10,6 @@ export default class PartnerSelector extends LitElement {
     partner: { type: Object },
     fieldLabels: { type: Object },
     seriesId: { type: String },
-    hasUnsavedChange: { type: Boolean },
   };
 
   constructor() {
@@ -18,8 +17,8 @@ export default class PartnerSelector extends LitElement {
     this.partner = this.partner || {
       name: '',
       link: '',
+      hasUnsavedChange: false,
     };
-    this.hasUnsavedChange = false;
   }
 
   static styles = style;
@@ -27,14 +26,14 @@ export default class PartnerSelector extends LitElement {
   firstUpdated() {
     this.imageDropzone = this.shadowRoot.querySelector('image-dropzone');
     this.imageDropzone.addEventListener('image-change', () => {
-      this.hasUnsavedChange = true;
+      this.partner.hasUnsavedChanges = true;
       this.requestUpdate();
     });
     this.checkValidity();
   }
 
   updateValue(key, value) {
-    this.hasUnsavedChange = true;
+    this.partner.hasUnsavedChanges = true;
     const saveButton = this.shadowRoot.querySelector('.save-partner-button');
     if (saveButton) saveButton.textContent = 'Save Partner';
 
@@ -82,12 +81,12 @@ export default class PartnerSelector extends LitElement {
         if (sponsorData) {
           this.partner.modificationTime = sponsorData.modificationTime;
           if (saveButton) {
-            this.hasUnsavedChange = false;
+            this.partner.hasUnsavedChanges = false;
             saveButton.textContent = 'Saved';
           }
         }
       } else if (saveButton) {
-        this.hasUnsavedChange = false;
+        this.partner.hasUnsavedChanges = false;
         saveButton.textContent = 'Saved';
       }
 
@@ -122,7 +121,7 @@ export default class PartnerSelector extends LitElement {
         </div>
       </div>
       <div class="action-area">
-        <sp-button variant="primary" ?disabled=${!this.checkValidity() || !this.hasUnsavedChange} class="save-partner-button" @click=${this.savePartner}>Save Partner</sp-button>
+        <sp-button variant="primary" ?disabled=${!this.checkValidity() || !this.partner.hasUnsavedChanges} class="save-partner-button" @click=${this.savePartner}>Save Partner</sp-button>
         <slot name="delete-btn"></slot>
         </div>
       </fieldset>

--- a/ecc/components/partner-selector/partner-selector.js
+++ b/ecc/components/partner-selector/partner-selector.js
@@ -14,7 +14,7 @@ export default class PartnerSelector extends LitElement {
 
   constructor() {
     super();
-    this.partner = this.partner || {
+    this.partner = { ...this.partner, isValid: true } || {
       isValid: false,
       name: '',
       link: '',
@@ -75,6 +75,7 @@ export default class PartnerSelector extends LitElement {
 
         if (sponsorData) {
           this.partner.modificationTime = sponsorData.modificationTime;
+          if (saveButton) saveButton.disabled = true;
         }
       }
 

--- a/ecc/components/partner-selector/partner-selector.js
+++ b/ecc/components/partner-selector/partner-selector.js
@@ -25,8 +25,10 @@ export default class PartnerSelector extends LitElement {
 
   firstUpdated() {
     this.imageDropzone = this.shadowRoot.querySelector('image-dropzone');
-    this.imageDropzone.addEventListener('image-change', () => {
+    this.imageDropzone.addEventListener('image-change', (e) => {
       this.partner.hasUnsavedChanges = true;
+      this.partner.photo = e.detail.file;
+      this.requestUpdate();
     });
     this.checkValidity();
   }

--- a/ecc/components/partner-selector/partner-selector.js
+++ b/ecc/components/partner-selector/partner-selector.js
@@ -27,6 +27,7 @@ export default class PartnerSelector extends LitElement {
     this.imageDropzone = this.shadowRoot.querySelector('image-dropzone');
     this.imageDropzone.addEventListener('image-change', () => {
       this.hasUnsavedChange = true;
+      this.requestUpdate();
     });
     this.checkValidity();
   }

--- a/ecc/components/partner-selector/partner-selector.js
+++ b/ecc/components/partner-selector/partner-selector.js
@@ -83,6 +83,9 @@ export default class PartnerSelector extends LitElement {
             saveButton.textContent = 'Saved';
           }
         }
+      } else if (saveButton) {
+        this.hasUnsavedChange = false;
+        saveButton.textContent = 'Saved';
       }
 
       this.requestUpdate();

--- a/ecc/components/partner-selector/partner-selector.js
+++ b/ecc/components/partner-selector/partner-selector.js
@@ -27,7 +27,6 @@ export default class PartnerSelector extends LitElement {
     this.imageDropzone = this.shadowRoot.querySelector('image-dropzone');
     this.imageDropzone.addEventListener('image-change', () => {
       this.partner.hasUnsavedChanges = true;
-      this.requestUpdate();
     });
     this.checkValidity();
   }

--- a/ecc/components/partner-selector/partner-selector.js
+++ b/ecc/components/partner-selector/partner-selector.js
@@ -85,7 +85,7 @@ export default class PartnerSelector extends LitElement {
         }
       }
 
-      // this.requestUpdate();
+      this.requestUpdate();
     }
 
     saveButton.pending = false;

--- a/ecc/components/partner-selector/partner-selector.js
+++ b/ecc/components/partner-selector/partner-selector.js
@@ -28,10 +28,13 @@ export default class PartnerSelector extends LitElement {
   }
 
   updateValue(key, value) {
-    this.partner = { ...this.partner, [key]: value };
     const imageDropzone = this.shadowRoot.querySelector('image-dropzone');
+    const saveButton = this.shadowRoot.querySelector('.save-partner-button');
+    if (saveButton) saveButton.textContent = 'Save Partner';
+
+    this.partner = { ...this.partner, [key]: value };
     this.partner.photo = imageDropzone?.file || null;
-    // this.checkValidity();
+
     this.dispatchEvent(new CustomEvent('update-partner', {
       detail: { partner: this.partner },
       bubbles: true,
@@ -73,11 +76,14 @@ export default class PartnerSelector extends LitElement {
 
         if (sponsorData) {
           this.partner.modificationTime = sponsorData.modificationTime;
-          if (saveButton) saveButton.disabled = true;
+          if (saveButton) {
+            saveButton.disabled = true;
+            saveButton.textContent = 'Saved';
+          }
         }
       }
 
-      this.requestUpdate();
+      // this.requestUpdate();
     }
 
     saveButton.pending = false;

--- a/ecc/components/partner-selector/partner-selector.js
+++ b/ecc/components/partner-selector/partner-selector.js
@@ -25,9 +25,9 @@ export default class PartnerSelector extends LitElement {
 
   firstUpdated() {
     this.imageDropzone = this.shadowRoot.querySelector('image-dropzone');
-    this.imageDropzone.handleImage = () => {
+    this.imageDropzone.addEventListener('image-change', () => {
       this.hasUnsavedChange = true;
-    };
+    });
     this.checkValidity();
   }
 

--- a/ecc/scripts/esp-controller.js
+++ b/ecc/scripts/esp-controller.js
@@ -176,7 +176,7 @@ export async function updateSponsor(data, sponsorId, seriesId) {
 
   const resp = await fetch(`${host}/v1/series/${seriesId}/sponsors/${sponsorId}`, options)
     .then((res) => res.json())
-    .catch((error) => window.lana?.log('Failed to update partner. Error:', error));
+    .catch((error) => window.lana?.log('Failed to update sponsor. Error:', error));
 
   return resp;
 }
@@ -188,7 +188,19 @@ export async function addSponsorToEvent(data, eventId) {
 
   const resp = await fetch(`${host}/v1/events/${eventId}/sponsors`, options)
     .then((res) => res.json())
-    .catch((error) => window.lana?.log('Failed to add partner to event. Error:', error));
+    .catch((error) => window.lana?.log('Failed to add sponsor to event. Error:', error));
+
+  return resp;
+}
+
+export async function updateSponsorInEvent(data, sponsorId, eventId) {
+  const { host } = getAPIConfig().esp[ECC_ENV];
+  const raw = JSON.stringify(data);
+  const options = await constructRequestOptions('POST', raw);
+
+  const resp = await fetch(`${host}/v1/events/${eventId}/sponsors/${sponsorId}`, options)
+    .then((res) => res.json())
+    .catch((error) => window.lana?.log('Failed to update sponsor in event. Error:', error));
 
   return resp;
 }
@@ -199,7 +211,7 @@ export async function removeSponsorFromEvent(sponsorId, eventId) {
 
   const resp = await fetch(`${host}/v1/events/${eventId}/sponsors/${sponsorId}`, options)
     .then((res) => res.json())
-    .catch((error) => window.lana?.log('Failed to delete partner from event. Error:', error));
+    .catch((error) => window.lana?.log('Failed to delete sponsor from event. Error:', error));
 
   return resp;
 }
@@ -210,7 +222,7 @@ export async function getSponsor(seriesId, sponsorId) {
 
   const resp = await fetch(`${host}/v1/series/${seriesId}/sponsors/${sponsorId}`, options)
     .then((res) => res.json())
-    .catch((error) => window.lana?.log('Failed to get partner. Error:', error));
+    .catch((error) => window.lana?.log('Failed to get sponsor. Error:', error));
 
   return resp;
 }

--- a/ecc/scripts/esp-controller.js
+++ b/ecc/scripts/esp-controller.js
@@ -195,7 +195,7 @@ export async function addSponsorToEvent(data, eventId) {
 
 export async function removeSponsorFromEvent(sponsorId, eventId) {
   const { host } = getAPIConfig().esp[ECC_ENV];
-  const options = await constructRequestOptions('DELETE', raw);
+  const options = await constructRequestOptions('DELETE');
 
   const resp = await fetch(`${host}/v1/events/${eventId}/sponsors/${sponsorId}`, options)
     .then((res) => res.json())

--- a/ecc/scripts/esp-controller.js
+++ b/ecc/scripts/esp-controller.js
@@ -193,6 +193,18 @@ export async function addSponsorToEvent(data, eventId) {
   return resp;
 }
 
+export async function getSponsor(seriesId, sponsorId) {
+  const { host } = getAPIConfig().esp[ECC_ENV];
+  const raw = JSON.stringify(data);
+  const options = await constructRequestOptions('GET', raw);
+
+  const resp = await fetch(`${host}/v1/series/${seriesId}/sponsors/${sponsorId}`, options)
+    .then((res) => res.json())
+    .catch((error) => window.lana?.log('Failed to update partner. Error:', error));
+
+  return resp;
+}
+
 export async function addSpeakerToEvent(speakerData, eventId) {
   const { host } = getAPIConfig().esp[ECC_ENV];
   const raw = JSON.stringify(speakerData);

--- a/ecc/scripts/esp-controller.js
+++ b/ecc/scripts/esp-controller.js
@@ -195,8 +195,7 @@ export async function addSponsorToEvent(data, eventId) {
 
 export async function getSponsor(seriesId, sponsorId) {
   const { host } = getAPIConfig().esp[ECC_ENV];
-  const raw = JSON.stringify(data);
-  const options = await constructRequestOptions('GET', raw);
+  const options = await constructRequestOptions('GET');
 
   const resp = await fetch(`${host}/v1/series/${seriesId}/sponsors/${sponsorId}`, options)
     .then((res) => res.json())

--- a/ecc/scripts/esp-controller.js
+++ b/ecc/scripts/esp-controller.js
@@ -196,7 +196,7 @@ export async function addSponsorToEvent(data, eventId) {
 export async function updateSponsorInEvent(data, sponsorId, eventId) {
   const { host } = getAPIConfig().esp[ECC_ENV];
   const raw = JSON.stringify(data);
-  const options = await constructRequestOptions('POST', raw);
+  const options = await constructRequestOptions('PUT', raw);
 
   const resp = await fetch(`${host}/v1/events/${eventId}/sponsors/${sponsorId}`, options)
     .then((res) => res.json())

--- a/ecc/scripts/esp-controller.js
+++ b/ecc/scripts/esp-controller.js
@@ -188,7 +188,18 @@ export async function addSponsorToEvent(data, eventId) {
 
   const resp = await fetch(`${host}/v1/events/${eventId}/sponsors`, options)
     .then((res) => res.json())
-    .catch((error) => window.lana?.log('Failed to update partner. Error:', error));
+    .catch((error) => window.lana?.log('Failed to add partner to event. Error:', error));
+
+  return resp;
+}
+
+export async function removeSponsorFromEvent(sponsorId, eventId) {
+  const { host } = getAPIConfig().esp[ECC_ENV];
+  const options = await constructRequestOptions('DELETE', raw);
+
+  const resp = await fetch(`${host}/v1/events/${eventId}/sponsors/${sponsorId}`, options)
+    .then((res) => res.json())
+    .catch((error) => window.lana?.log('Failed to delete partner from event. Error:', error));
 
   return resp;
 }
@@ -199,7 +210,7 @@ export async function getSponsor(seriesId, sponsorId) {
 
   const resp = await fetch(`${host}/v1/series/${seriesId}/sponsors/${sponsorId}`, options)
     .then((res) => res.json())
-    .catch((error) => window.lana?.log('Failed to update partner. Error:', error));
+    .catch((error) => window.lana?.log('Failed to get partner. Error:', error));
 
   return resp;
 }

--- a/ecc/scripts/utils.js
+++ b/ecc/scripts/utils.js
@@ -1,28 +1,8 @@
-import { MILO_CONFIG } from './scripts.js';
+import { MILO_CONFIG, LIBS } from './scripts.js';
+
+const { createTag } = await import(`${LIBS}/utils/utils.js`);
 
 let secretCache = [];
-
-function createTag(tag, attributes, html, options = {}) {
-  const el = document.createElement(tag);
-  if (html) {
-    if (html instanceof HTMLElement
-      || html instanceof SVGElement
-      || html instanceof DocumentFragment) {
-      el.append(html);
-    } else if (Array.isArray(html)) {
-      el.append(...html);
-    } else {
-      el.insertAdjacentHTML('beforeend', html);
-    }
-  }
-  if (attributes) {
-    Object.entries(attributes).forEach(([key, val]) => {
-      el.setAttribute(key, val);
-    });
-  }
-  options.parent?.append(el);
-  return el;
-}
 
 export function getIcon(tag) {
   const img = document.createElement('img');


### PR DESCRIPTION
Fetch each sponsor to re-populate the ECC form with existing sponsors attached to the event
Also fixed some other ECC form bugs

Resolves: https://jira.corp.adobe.com/browse/MWPW-148089

Test URLs:
- Before: https://dev--ecc-milo--adobecom.hlx.page/ecc/create/t3?eventId=f11eddac-3c96-41cd-8fe6-2731f3116c58&devMode=true
- After: https://sponsor-fetch--ecc-milo--adobecom.hlx.page/ecc/create/t3?eventId=f11eddac-3c96-41cd-8fe6-2731f3116c58&devMode=true
