### PR TITLE
Fixing add profile repeater not enabled for fetched speaker profile

### DIFF
--- a/ecc/blocks/form-handler/form-handler.js
+++ b/ecc/blocks/form-handler/form-handler.js
@@ -399,41 +399,6 @@ function initRequiredFieldsValidation(props) {
   inputValidationCB();
 }
 
-// function setRemoveEventListener(removeElement) {
-//   removeElement.addEventListener('click', (event) => {
-//     // FIXME : Use a generic approach to call remove of the handler.
-//     // event.currentTarget.getAttribute('deleteHandler')();
-//     event.currentTarget.parentNode.parentNode.parentNode.remove();
-//   });
-// }
-
-// function initRepeaters(props) {
-//   const repeaters = props.el.querySelectorAll('.repeater-element');
-//   repeaters.forEach((element) => {
-//     const vanillaNode = element.previousElementSibling.cloneNode(true);
-//     element.addEventListener('click', (event) => {
-//       const clonedNode = vanillaNode.cloneNode(true);
-//       const prevNode = event.currentTarget.previousElementSibling;
-//       clonedNode.setAttribute('repeatIdx', parseInt(prevNode.getAttribute('repeatIdx'), 10) + 1);
-
-//       // Reset delete icon state and add listener.
-//       const deleteIcon = clonedNode.querySelector('.repeater-delete-button');
-
-//       if (deleteIcon) {
-//         deleteIcon.classList.remove('hidden');
-//         setRemoveEventListener(deleteIcon);
-//       }
-
-//       prevNode.after(clonedNode);
-//       const tempProps = { el: clonedNode };
-//       yieldToMain().then(() => {
-//         updateRequiredFields(props);
-//         initRepeaters(tempProps);
-//       });
-//     });
-//   });
-// }
-
 function renderFormNavigation(props, prevStep, currentStep) {
   const nextBtn = props.el.querySelector('.form-handler-ctas-panel .next-button');
   const backBtn = props.el.querySelector('.form-handler-ctas-panel .back-btn');

--- a/ecc/blocks/form-handler/form-handler.js
+++ b/ecc/blocks/form-handler/form-handler.js
@@ -750,7 +750,6 @@ async function buildECCForm(el) {
   initFormCtas(proxyProps);
   initNavigation(proxyProps);
   await initComponents(proxyProps);
-  initRepeaters(proxyProps);
   updateRequiredFields(proxyProps);
   enableSideNavForEditFlow(proxyProps);
   initDeepLink(proxyProps);

--- a/ecc/blocks/form-handler/form-handler.js
+++ b/ecc/blocks/form-handler/form-handler.js
@@ -399,40 +399,40 @@ function initRequiredFieldsValidation(props) {
   inputValidationCB();
 }
 
-function setRemoveEventListener(removeElement) {
-  removeElement.addEventListener('click', (event) => {
-    // FIXME : Use a generic approach to call remove of the handler.
-    // event.currentTarget.getAttribute('deleteHandler')();
-    event.currentTarget.parentNode.parentNode.parentNode.remove();
-  });
-}
+// function setRemoveEventListener(removeElement) {
+//   removeElement.addEventListener('click', (event) => {
+//     // FIXME : Use a generic approach to call remove of the handler.
+//     // event.currentTarget.getAttribute('deleteHandler')();
+//     event.currentTarget.parentNode.parentNode.parentNode.remove();
+//   });
+// }
 
-function initRepeaters(props) {
-  const repeaters = props.el.querySelectorAll('.repeater-element');
-  repeaters.forEach((element) => {
-    const vanillaNode = element.previousElementSibling.cloneNode(true);
-    element.addEventListener('click', (event) => {
-      const clonedNode = vanillaNode.cloneNode(true);
-      const prevNode = event.currentTarget.previousElementSibling;
-      clonedNode.setAttribute('repeatIdx', parseInt(prevNode.getAttribute('repeatIdx'), 10) + 1);
+// function initRepeaters(props) {
+//   const repeaters = props.el.querySelectorAll('.repeater-element');
+//   repeaters.forEach((element) => {
+//     const vanillaNode = element.previousElementSibling.cloneNode(true);
+//     element.addEventListener('click', (event) => {
+//       const clonedNode = vanillaNode.cloneNode(true);
+//       const prevNode = event.currentTarget.previousElementSibling;
+//       clonedNode.setAttribute('repeatIdx', parseInt(prevNode.getAttribute('repeatIdx'), 10) + 1);
 
-      // Reset delete icon state and add listener.
-      const deleteIcon = clonedNode.querySelector('.repeater-delete-button');
+//       // Reset delete icon state and add listener.
+//       const deleteIcon = clonedNode.querySelector('.repeater-delete-button');
 
-      if (deleteIcon) {
-        deleteIcon.classList.remove('hidden');
-        setRemoveEventListener(deleteIcon);
-      }
+//       if (deleteIcon) {
+//         deleteIcon.classList.remove('hidden');
+//         setRemoveEventListener(deleteIcon);
+//       }
 
-      prevNode.after(clonedNode);
-      const tempProps = { el: clonedNode };
-      yieldToMain().then(() => {
-        updateRequiredFields(props);
-        initRepeaters(tempProps);
-      });
-    });
-  });
-}
+//       prevNode.after(clonedNode);
+//       const tempProps = { el: clonedNode };
+//       yieldToMain().then(() => {
+//         updateRequiredFields(props);
+//         initRepeaters(tempProps);
+//       });
+//     });
+//   });
+// }
 
 function renderFormNavigation(props, prevStep, currentStep) {
   const nextBtn = props.el.querySelector('.form-handler-ctas-panel .next-button');

--- a/ecc/blocks/form-handler/form-handler.js
+++ b/ecc/blocks/form-handler/form-handler.js
@@ -753,6 +753,11 @@ async function buildECCForm(el) {
   updateRequiredFields(proxyProps);
   enableSideNavForEditFlow(proxyProps);
   initDeepLink(proxyProps);
+  el.addEventListener('show-error-toast', (e) => {
+    e.stopPropagation();
+    e.preventDefault();
+    buildErrorMessage(proxyProps, e.detail);
+  });
 }
 
 export default async function init(el) {

--- a/ecc/components/custom-search/custom-search.js
+++ b/ecc/components/custom-search/custom-search.js
@@ -98,7 +98,7 @@ export class CustomSearch extends LitElement {
     this.dispatchEvent(
       new CustomEvent(
         'profile-selected',
-        { detail: { profile: { ...profile } } },
+        { detail: { profile: { ...profile, isPlaceholder: false } } },
       ),
     );
   }

--- a/ecc/components/image-dropzone/image-dropzone.js
+++ b/ecc/components/image-dropzone/image-dropzone.js
@@ -23,6 +23,7 @@ export class ImageDropzone extends LitElement {
   setFile(files) {
     const [file] = files;
     if (file.size > 26214400) {
+      this.dispatchEvent(new CustomEvent('show-error-toast', { detail: { message: 'File size should be less than 25MB' }, bubbles: true, composed: true }));
       return;
     }
     if (file.type.startsWith('image/')) {

--- a/ecc/components/profile/profile.css.js
+++ b/ecc/components/profile/profile.css.js
@@ -101,9 +101,16 @@ modal{
   margin: 0;
 }
 
+.preview-wrapper {
+  height: 200px;
+}
+
+.preview-img-placeholder {
+  height: 100%;
+}
+
 .speaker-image {
   width: 300px;
-  max-width: 100%;
   height: 100%;
   display: block;
   object-fit: cover;

--- a/ecc/components/profile/profile.js
+++ b/ecc/components/profile/profile.js
@@ -78,7 +78,7 @@ export class Profile extends LitElement {
     const fieldLabel = this.getRequiredProps().fieldLabelsJSON.chooseType ?? DEFAULT_FIELD_LABELS.chooseType;
     return html`
     <div>
-    <div><sp-field-label size="l" required>${fieldLabel}</sp-field-label></div>
+    <div><sp-field-label size="l" required>${fieldLabel} *</sp-field-label></div>
     <sp-picker label=${fieldLabel} value=${this.profile?.type} size="l" @change=${(event) => this.updateProfile({ type: event.target.value })}>
         ${repeat(SPEAKER_TYPE, (type) => html`
             <sp-menu-item value="${type}">${type}</sp-menu-item>

--- a/ecc/components/profile/profile.js
+++ b/ecc/components/profile/profile.js
@@ -21,7 +21,9 @@ const DEFAULT_FIELD_LABELS = {
 };
 
 const SPEAKER_TYPE = ['Host', 'Speaker'];
-const SUPPORTED_SOCIAL = ['facebook', 'instagram', 'x', 'twitter', 'linkedin', 'pinterest', 'discord', 'behance', 'youtube', 'weibo', 'social-media'];
+// eslint-disable-next-line max-len
+// const SUPPORTED_SOCIAL = ['facebook', 'instagram', 'x', 'twitter', 'linkedin', 'pinterest', 'discord', 'behance', 'youtube', 'weibo', 'social-media'];
+const SUPPORTED_SOCIAL = ['YouTube', 'LinkedIn', 'Web', 'X', 'TikTok', 'Instagram', 'Facebook', 'Pinterest'];
 
 export class Profile extends LitElement {
   static properties = {
@@ -59,8 +61,16 @@ export class Profile extends LitElement {
   }
 
   updateSocialMedia(index, value) {
-    this.profile.socialMedia[index] = { link: value, serviceName: getServiceName(value) };
-    this.requestUpdate();
+    const tempServiceName = getServiceName(value);
+    // eslint-disable-next-line max-len
+    const serviceName = SUPPORTED_SOCIAL.find((service) => service.toLowerCase() === tempServiceName.toLowerCase());
+    if (serviceName === undefined) {
+      this.dispatchEvent(new CustomEvent('show-error-toast', { detail: { message: 'Invalid social media not accepted' }, bubbles: true, composed: true }));
+    } else {
+      // eslint-disable-next-line max-len
+      this.profile.socialMedia[index] = { link: value, serviceName };
+      this.requestUpdate();
+    }
   }
 
   renderProfileTypePicker() {
@@ -95,10 +105,19 @@ export class Profile extends LitElement {
         respJson = await createSpeaker(profile, this.seriesId);
       }
 
+      if (respJson.errors || respJson.message) {
+        window.lana?.log(`error occured while saving profile ${respJson.errors ?? respJson.message}`);
+        saveButton.pending = false;
+        const { errors, message } = respJson;
+        this.dispatchEvent(new CustomEvent('show-error-toast', { detail: { errors, message }, bubbles: true, composed: true }));
+        return;
+      }
+
       if (respJson.speakerId) {
         profile.speakerId = respJson.speakerId;
         profile.photo = imageDropzone?.file ? { imageUrl: imageDropzone?.file?.url } : null;
         const file = imageDropzone?.getFile();
+        profile.modificationTime = respJson.modificationTime;
 
         if (file && (file instanceof File)) {
           const speakerData = await uploadImage(file, {
@@ -288,7 +307,7 @@ export class Profile extends LitElement {
   }
 
   renderSocialMediaLink(socialMedia) {
-    const serviceName = SUPPORTED_SOCIAL.includes(socialMedia.serviceName) ? socialMedia.serviceName : 'social-media';
+    const serviceName = SUPPORTED_SOCIAL.includes(socialMedia.serviceName) ? socialMedia.serviceName.toLowerCase() : 'social-media';
     return socialMedia.link ? html`<div class="social-media-row">
     <svg xmlns="http://www.w3.org/2000/svg" class="feds-social-icon" alt="${serviceName} logo">
       <use href="#footer-icon-${serviceName}"></use>

--- a/ecc/scripts/esp-controller.js
+++ b/ecc/scripts/esp-controller.js
@@ -383,6 +383,11 @@ export async function getVenue(eventId) {
   return resp;
 }
 
+function convertNspeakerToSpeaker(speaker) {
+  speaker.isPlaceholder = false;
+  return speaker;
+}
+
 export async function getSpeaker(seriesId, speakerId) {
   const { host } = getAPIConfig().esp[ECC_ENV];
   const options = await constructRequestOptions('GET');
@@ -391,7 +396,7 @@ export async function getSpeaker(seriesId, speakerId) {
     .then((res) => res.json())
     .catch((error) => window.lana?.log(`Failed to get venue details. Error: ${error}`));
 
-  return resp;
+  return convertNspeakerToSpeaker(resp);
 }
 
 export async function getClouds() {
@@ -493,12 +498,7 @@ export async function getSpeakers(seriesId) {
     .then((res) => res.json())
     .catch((error) => window.lana?.log(`Failed to get details of speakers for series ${seriesId}. Error: ${error}`));
 
-  return {
-    speakers: resp.speakers.map((speaker) => {
-      speaker.isPlaceholder = false;
-      return speaker;
-    }),
-  };
+  return { speakers: resp.speakers.map(convertNspeakerToSpeaker) };
 }
 
 export async function getEventImages(eventId) {

--- a/ecc/scripts/esp-controller.js
+++ b/ecc/scripts/esp-controller.js
@@ -493,10 +493,12 @@ export async function getSpeakers(seriesId) {
     .then((res) => res.json())
     .catch((error) => window.lana?.log(`Failed to get details of speakers for series ${seriesId}. Error: ${error}`));
 
-  return resp.map((speaker) => {
-    speaker.isPlaceholder = false;
-    return speaker;
-  });
+  return {
+    speakers: resp.speakers.map((speaker) => {
+      speaker.isPlaceholder = false;
+      return speaker;
+    }),
+  };
 }
 
 export async function getEventImages(eventId) {

--- a/ecc/scripts/esp-controller.js
+++ b/ecc/scripts/esp-controller.js
@@ -160,7 +160,7 @@ export async function createEvent(payload) {
 function convertToNSpeaker(profile) {
   const {
     // eslint-disable-next-line max-len
-    speakerId, firstName, lastName, title, company, bio, socialLinks, creationTime, modificationTime,
+    speakerId, firstName, lastName, title, company, bio, socialMedia, creationTime, modificationTime,
   } = profile;
 
   return {
@@ -170,7 +170,7 @@ function convertToNSpeaker(profile) {
     title,
     company,
     bio,
-    socialLinks,
+    socialLinks: socialMedia,
     creationTime,
     modificationTime,
   };
@@ -383,9 +383,23 @@ export async function getVenue(eventId) {
   return resp;
 }
 
-function convertNspeakerToSpeaker(speaker) {
-  speaker.isPlaceholder = false;
-  return speaker;
+function convertToSpeaker(speaker) {
+  const {
+    // eslint-disable-next-line max-len
+    speakerId, firstName, lastName, title, company, bio, socialLinks, creationTime, modificationTime,
+  } = speaker;
+
+  return {
+    speakerId,
+    firstName,
+    lastName,
+    title,
+    company,
+    bio,
+    socialMedia: socialLinks || [],
+    creationTime,
+    modificationTime,
+  };
 }
 
 export async function getSpeaker(seriesId, speakerId) {
@@ -396,7 +410,7 @@ export async function getSpeaker(seriesId, speakerId) {
     .then((res) => res.json())
     .catch((error) => window.lana?.log(`Failed to get venue details. Error: ${error}`));
 
-  return convertNspeakerToSpeaker(resp);
+  return convertToSpeaker(resp);
 }
 
 export async function getClouds() {
@@ -498,7 +512,7 @@ export async function getSpeakers(seriesId) {
     .then((res) => res.json())
     .catch((error) => window.lana?.log(`Failed to get details of speakers for series ${seriesId}. Error: ${error}`));
 
-  return { speakers: resp.speakers.map(convertNspeakerToSpeaker) };
+  return { speakers: resp.speakers.map(convertToSpeaker) };
 }
 
 export async function getEventImages(eventId) {

--- a/ecc/scripts/esp-controller.js
+++ b/ecc/scripts/esp-controller.js
@@ -301,9 +301,9 @@ export async function updateSpeaker(profile, seriesId) {
   const raw = JSON.stringify({ ...nSpeaker, seriesId });
   const options = await constructRequestOptions('PUT', raw);
 
+
   const resp = await fetch(`${host}/v1/series/${seriesId}/speakers/${profile.speakerId}`, options)
-    .then((res) => res.json())
-    .catch((error) => window.lana?.log(`Failed to update speaker. Error: ${error}`));
+    .then((res) => res.json());
 
   return resp;
 }

--- a/ecc/scripts/esp-controller.js
+++ b/ecc/scripts/esp-controller.js
@@ -302,7 +302,8 @@ export async function updateSpeaker(profile, seriesId) {
   const options = await constructRequestOptions('PUT', raw);
 
   const resp = await fetch(`${host}/v1/series/${seriesId}/speakers/${profile.speakerId}`, options)
-    .then((res) => res.json());
+    .then((res) => res.json())
+    .catch((error) => window.lana?.log(`Failed to update speaker. Error: ${error}`));
 
   return resp;
 }

--- a/ecc/scripts/esp-controller.js
+++ b/ecc/scripts/esp-controller.js
@@ -301,7 +301,6 @@ export async function updateSpeaker(profile, seriesId) {
   const raw = JSON.stringify({ ...nSpeaker, seriesId });
   const options = await constructRequestOptions('PUT', raw);
 
-
   const resp = await fetch(`${host}/v1/series/${seriesId}/speakers/${profile.speakerId}`, options)
     .then((res) => res.json());
 
@@ -386,7 +385,7 @@ export async function getVenue(eventId) {
 function convertToSpeaker(speaker) {
   const {
     // eslint-disable-next-line max-len
-    speakerId, firstName, lastName, title, company, bio, socialLinks, creationTime, modificationTime,
+    speakerId, firstName, lastName, title, company, bio, socialLinks, creationTime, modificationTime, photo,
   } = speaker;
 
   return {
@@ -396,6 +395,7 @@ function convertToSpeaker(speaker) {
     title,
     company,
     bio,
+    photo,
     socialMedia: socialLinks || [],
     creationTime,
     modificationTime,

--- a/ecc/scripts/utils.js
+++ b/ecc/scripts/utils.js
@@ -113,22 +113,6 @@ export function querySelectorAllDeep(selector, root = document) {
   return elements;
 }
 
-// export function addRepeater(element, title) {
-//   if (!element) return;
-//   element.setAttribute('repeatIdx', 0);
-
-//   const tag = createTag('div');
-//   tag.classList.add('repeater-element');
-
-//   const heading = createTag('h3', { class: 'repeater-element-title' }, title);
-//   tag.append(heading);
-
-//   const plusIcon = getIcon('add-circle');
-//   tag.append(plusIcon);
-
-//   element.after(tag);
-// }
-
 function mergeOptions(defaultOptions, overrideOptions) {
   const combinedOptions = { ...defaultOptions, ...overrideOptions };
 

--- a/ecc/scripts/utils.js
+++ b/ecc/scripts/utils.js
@@ -113,21 +113,21 @@ export function querySelectorAllDeep(selector, root = document) {
   return elements;
 }
 
-export function addRepeater(element, title) {
-  if (!element) return;
-  element.setAttribute('repeatIdx', 0);
+// export function addRepeater(element, title) {
+//   if (!element) return;
+//   element.setAttribute('repeatIdx', 0);
 
-  const tag = createTag('div');
-  tag.classList.add('repeater-element');
+//   const tag = createTag('div');
+//   tag.classList.add('repeater-element');
 
-  const heading = createTag('h3', { class: 'repeater-element-title' }, title);
-  tag.append(heading);
+//   const heading = createTag('h3', { class: 'repeater-element-title' }, title);
+//   tag.append(heading);
 
-  const plusIcon = getIcon('add-circle');
-  tag.append(plusIcon);
+//   const plusIcon = getIcon('add-circle');
+//   tag.append(plusIcon);
 
-  element.after(tag);
-}
+//   element.after(tag);
+// }
 
 function mergeOptions(defaultOptions, overrideOptions) {
   const combinedOptions = { ...defaultOptions, ...overrideOptions };


### PR DESCRIPTION
isPlaceholder is returned as true for some saved profiles. ideally it should not be stored and returned from backend. Adding checks to prevent handling of this.
And other minor fixes
1. Sending social links instead of social media in speaker body
2. Showing error toast when speaker update/create fails
3. Showing error when image is > 25MB
4. Showing error when social media is out of the supported list

Resolves: [MWPW-154773](https://jira.corp.adobe.com/browse/MWPW-154773)

Test URLs:
- Before: https://main--ecc-milo--adobecom.hlx.page/
- After: https://gbajaj-bugfix--ecc-milo--adobecom.hlx.page/
