### PR TITLE
Sponsor Image fetch

### DIFF
--- a/ecc/blocks/form-handler/controllers/event-partners-component-controller.js
+++ b/ecc/blocks/form-handler/controllers/event-partners-component-controller.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-restricted-syntax */
-import { addSponsorToEvent, getSponsor, removeSponsorFromEvent, updateSponsorInEvent } from '../../../scripts/esp-controller.js';
+import { addSponsorToEvent, getSponsor, getSponsorImages, removeSponsorFromEvent, updateSponsorInEvent } from '../../../scripts/esp-controller.js';
 import { getFilteredCachedResponse } from '../data-handler.js';
 
 /* eslint-disable no-unused-vars */
@@ -104,6 +104,15 @@ export default async function init(component, props) {
           const { name, link, sponsorId } = partnerData;
           if (partnerData.image) {
             photo = { ...partnerData.image, url: partnerData.image.imageUrl };
+          } else {
+            const sponsorImages = await getSponsorImages(eventData.seriesId, sponsorId);
+
+            if (sponsorImages) {
+              const sponsorImage = sponsorImages.find((image) => image.imageKind === 'sponsor-image');
+              if (sponsorImage) {
+                photo = { ...sponsorImage, url: sponsorImage.imageUrl };
+              }
+            }
           }
 
           return {

--- a/ecc/scripts/esp-controller.js
+++ b/ecc/scripts/esp-controller.js
@@ -239,6 +239,17 @@ export async function getSponsor(seriesId, sponsorId) {
   return resp;
 }
 
+export async function getSponsorImages(seriesId, sponsorId) {
+  const { host } = getAPIConfig().esp[ECC_ENV];
+  const options = await constructRequestOptions('GET');
+
+  const resp = await fetch(`${host}/v1/series/${seriesId}/sponsors/${sponsorId}/images`, options)
+    .then((res) => res.json())
+    .catch((error) => window.lana?.log('Failed to get sponsor images. Error:', error));
+
+  return resp;
+}
+
 export async function addSpeakerToEvent(speakerData, eventId) {
   const { host } = getAPIConfig().esp[ECC_ENV];
   const raw = JSON.stringify(speakerData);


### PR DESCRIPTION
This update is to prepare for the change when the image gets removed from sponsor object and we'll need to make a separate call for it for each sponsor.

We need to validate after the backend change. Currently there's no data behind sponsors/images endpoint.

Resolves: ticket pending

Test URLs:
- Before: https://dev--ecc-milo--adobecom.hlx.page/
- After: https://sponsor-img-fetch--ecc-milo--adobecom.hlx.page/
