### PR TITLE
Community URL Submission Bug fix

### DIFF
--- a/ecc/blocks/form-handler/controllers/event-community-link-component-controller.js
+++ b/ecc/blocks/form-handler/controllers/event-community-link-component-controller.js
@@ -2,7 +2,7 @@
 import { changeInputValue } from '../../../scripts/utils.js';
 
 export function onSubmit(component, props) {
-  if (component.closest('.fragment')?.classList.contains('hidden')) return null;
+  if (component.closest('.fragment')?.classList.contains('hidden')) return;
 
   const checkbox = component.querySelector('#checkbox-community');
 
@@ -10,9 +10,6 @@ export function onSubmit(component, props) {
     const communityTopicUrl = component.querySelector('#community-url-details').value;
     props.payload = { ...props.payload, communityTopicUrl };
   }
-
-  delete props.payload.communityTopicUrl;
-  return {};
 }
 
 export async function onUpdate(_component, _props) {


### PR DESCRIPTION
Fixed the issue where the first submission doesn't send communityUrl

Test URLs:
- Before: https://dev--ecc-milo--adobecom.hlx.page/ecc/create/t3?devMode=true
- After: https://first-call-payload-fix--ecc-milo--adobecom.hlx.page/ecc/create/t3?devMode=true
