### PR TITLE
Fixing show error toast not shown for invalid link

### DIFF
--- a/ecc/components/profile/profile.js
+++ b/ecc/components/profile/profile.js
@@ -108,7 +108,7 @@ export class Profile extends LitElement {
         const { errors, message } = respJson.error;
         window.lana?.log(`error occured while saving profile ${errors ?? message}`);
         saveButton.pending = false;
-        this.dispatchEvent(new CustomEvent('show-error-toast', { detail: { errors, message }, bubbles: true, composed: true }));
+        this.dispatchEvent(new CustomEvent('show-error-toast', { detail: { error: { errors, message } }, bubbles: true, composed: true }));
         return;
       }
 


### PR DESCRIPTION
Describe your specific features or fixes and provide a preview link for the feature being incorporated

Resolves: [MWPW-155321](https://jira.corp.adobe.com/browse/MWPW-155321)

Test URLs:
- Before: https://main--ecc-milo--adobecom.hlx.page/
- After: https://MWPW-155321--ecc-milo--adobecom.hlx.page/
