### PR TITLE
expand account type whitelist

### DIFF
--- a/ecc/blocks/ecc-dashboard/ecc-dashboard.js
+++ b/ecc/blocks/ecc-dashboard/ecc-dashboard.js
@@ -6,6 +6,7 @@ import {
   publishEvent,
   unpublishEvent,
 } from '../../scripts/esp-controller.js';
+import { ALLOWED_ACCOUNT_TYPES } from '../../constants/constants.js';
 import { LIBS, MILO_CONFIG } from '../../scripts/scripts.js';
 import { getIcon, buildNoAccessScreen, getEventPageHost } from '../../scripts/utils.js';
 import { quickFilter } from '../form-handler/data-handler.js';
@@ -707,7 +708,7 @@ export default async function init(el) {
   }
 
   if (profile) {
-    if (profile.noProfile || profile.account_type !== 'type3') {
+    if (profile.noProfile || ALLOWED_ACCOUNT_TYPES.includes(profile.account_type)) {
       buildNoAccessScreen(el);
     } else {
       buildDashboard(el, config);
@@ -718,7 +719,7 @@ export default async function init(el) {
 
   if (!profile) {
     const unsubscribe = BlockMediator.subscribe('imsProfile', ({ newValue }) => {
-      if (newValue?.noProfile || newValue.account_type !== 'type3') {
+      if (newValue?.noProfile || ALLOWED_ACCOUNT_TYPES.includes(profile.account_type)) {
         buildNoAccessScreen(el);
       } else {
         buildDashboard(el, config);

--- a/ecc/blocks/form-handler/form-handler.js
+++ b/ecc/blocks/form-handler/form-handler.js
@@ -1,3 +1,4 @@
+import { ALLOWED_ACCOUNT_TYPES } from '../../constants/constants.js';
 import { LIBS, MILO_CONFIG } from '../../scripts/scripts.js';
 import {
   getIcon,
@@ -807,7 +808,7 @@ export default async function init(el) {
   }
 
   if (profile) {
-    if (profile.noProfile || profile.account_type !== 'type3') {
+    if (profile.noProfile || ALLOWED_ACCOUNT_TYPES.includes(profile.account_type)) {
       buildNoAccessScreen(el);
       el.classList.remove('loading');
     } else {
@@ -821,7 +822,7 @@ export default async function init(el) {
 
   if (!profile) {
     const unsubscribe = BlockMediator.subscribe('imsProfile', ({ newValue }) => {
-      if (newValue?.noProfile || newValue.account_type !== 'type3') {
+      if (newValue?.noProfile || ALLOWED_ACCOUNT_TYPES.includes(profile.account_type)) {
         buildNoAccessScreen(el);
         el.classList.remove('loading');
         unsubscribe();

--- a/ecc/constants/constants.js
+++ b/ecc/constants/constants.js
@@ -1,1 +1,2 @@
 export const LINK_REGEX = '^https:\\/\\/[a-z0-9]+([\\-\\.]{1}[a-z0-9]+)*\\.[a-z]{2,5}(:[0-9]{1,5})?(\\/.*)?$';
+export const ALLOWED_ACCOUNT_TYPES = ['type3', 'type2e'];


### PR DESCRIPTION
adding type2e to the ECC allowed account type

Test URLs:
- Before: https://dev--ecc-milo--adobecom.hlx.page/
- After: https://expand-account-type--ecc-milo--adobecom.hlx.page/
