### PR TITLE
[MWPW-156736] Validation state for partner URL does not clear

### DIFF
--- a/ecc/blocks/form-handler/controllers/event-format-component-controller.js
+++ b/ecc/blocks/form-handler/controllers/event-format-component-controller.js
@@ -24,14 +24,6 @@ function prepopulateTimeZone(component) {
 }
 
 function initStepLock(component) {
-  const { search } = window.location;
-  const urlParams = new URLSearchParams(search);
-  const skipValidation = urlParams.get('skipValidation');
-
-  if (skipValidation === 'true' && ['stage', 'local'].includes(MILO_CONFIG.env.name)) {
-    return;
-  }
-
   const step = component.closest('.fragment');
   const inputs = component.querySelectorAll('#bu-select-input, #series-select-input');
 

--- a/ecc/blocks/form-handler/form-handler.js
+++ b/ecc/blocks/form-handler/form-handler.js
@@ -151,14 +151,6 @@ function getCurrentFragment(props) {
 }
 
 function validateRequiredFields(fields) {
-  const { search } = window.location;
-  const urlParams = new URLSearchParams(search);
-  const skipValidation = urlParams.get('skipValidation');
-
-  if (skipValidation === 'true' && ['stage', 'local'].includes(MILO_CONFIG.env.name)) {
-    return true;
-  }
-
   return fields.length === 0 || Array.from(fields).every((f) => f.value);
 }
 

--- a/ecc/components/partner-selector/partner-selector.js
+++ b/ecc/components/partner-selector/partner-selector.js
@@ -154,9 +154,9 @@ export default class PartnerSelector extends LitElement {
             </div>
             <div class="partner-input">
               <label>${this.fieldLabels.urlLabelText}</label>
-              <sp-textfield pattern=${LINK_REGEX} value=${this.partner.link} placeholder="Enter partner full URL", @change=${(event) => {
+              <sp-textfield pattern=${LINK_REGEX} value=${this.partner.link} placeholder="Enter partner full URL" @change=${(event) => {
   this.updatePartner({ link: event.target.value });
-}}></sp-textfield>
+}} ?valid=${this.partner.link?.match(LINK_REGEX)}></sp-textfield>
             </div>
           </div>
         </div>

--- a/ecc/components/partner-selector/partner-selector.js
+++ b/ecc/components/partner-selector/partner-selector.js
@@ -156,6 +156,7 @@ export default class PartnerSelector extends LitElement {
               <label>${this.fieldLabels.urlLabelText}</label>
               <sp-textfield pattern=${LINK_REGEX} value=${this.partner.link} placeholder="Enter partner full URL" @change=${(event) => {
   this.updatePartner({ link: event.target.value });
+  // FIXME: I really shouldn't need to do this, but the pattern attribute doesn't reset properly.
 }} ?valid=${this.partner.link?.match(LINK_REGEX)}></sp-textfield>
             </div>
           </div>


### PR DESCRIPTION
Resolves: [MWPW-156736](https://jira.corp.adobe.com/browse/MWPW-156736)

Test URLs:
- Before: https://dev--ecc-milo--adobecom.hlx.page/ecc/create/t3?eventId=f11eddac-3c96-41cd-8fe6-2731f3116c58&devMode=true
- After: https://partner-validate-bug-fix--ecc-milo--adobecom.hlx.page/ecc/create/t3?eventId=f11eddac-3c96-41cd-8fe6-2731f3116c58&devMode=true
