### PR TITLE
[CHORE] Enhance devToken sustaining

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,8 +3,8 @@ Describe your specific features or fixes and provide a preview link for the feat
 Resolves: [MWPW-NUMBER](https://jira.corp.adobe.com/browse/MWPW-NUMBER)
 
 Test URLs:
-- Before: https://main--ecc-milo--adobecom.hlx.page/
-- After: https://<branch>--ecc-milo--adobecom.hlx.page/
+- Before: https://main--ecc-milo--adobecom.hlx.live/drafts/
+- After: https://<branch>--ecc-milo--adobecom.hlx.live/drafts/
 
 To test the feature, please load up the branch locally and run it against your local ESP and ESL server.
 For more information on how to set up ESL and ESP locally, please refer to: https://wiki.corp.adobe.com/display/adobedotcom/Events+Milo+FE+Dev+Wiki#EventsMiloFEDevWiki-Localdevelopmentsetup

--- a/ecc/blocks/attendee-management-table/attendee-management-table.js
+++ b/ecc/blocks/attendee-management-table/attendee-management-table.js
@@ -8,6 +8,7 @@ import {
   readBlockConfig,
   signIn,
   getEventServiceEnv,
+  getDevToken,
 } from '../../scripts/utils.js';
 import { SearchablePicker } from '../../components/searchable-picker/searchable-picker.js';
 import { FilterMenu } from '../../components/filter-menu/filter-menu.js';
@@ -715,8 +716,7 @@ export default async function init(el) {
   el.innerHTML = '';
   buildLoadingScreen(el);
 
-  const sp = new URLSearchParams(window.location.search);
-  const devToken = sp.get('devToken');
+  const devToken = getDevToken();
   if (devToken && getEventServiceEnv() === 'local') {
     buildDashboard(el, config);
     return;

--- a/ecc/blocks/ecc-dashboard/ecc-dashboard.js
+++ b/ecc/blocks/ecc-dashboard/ecc-dashboard.js
@@ -14,6 +14,7 @@ import {
   readBlockConfig,
   signIn,
   getEventServiceEnv,
+  getDevToken,
 } from '../../scripts/utils.js';
 import { quickFilter } from '../form-handler/data-handler.js';
 import { initProfileLogicTree } from '../../scripts/event-apis.js';
@@ -731,8 +732,7 @@ export default async function init(el) {
   el.innerHTML = '';
   buildLoadingScreen(el);
 
-  const sp = new URLSearchParams(window.location.search);
-  const devToken = sp.get('devToken');
+  const devToken = getDevToken();
   if (devToken && getEventServiceEnv() === 'local') {
     buildDashboard(el, config);
     return;

--- a/ecc/blocks/form-handler/form-handler.js
+++ b/ecc/blocks/form-handler/form-handler.js
@@ -7,6 +7,7 @@ import {
   getEventPageHost,
   signIn,
   getEventServiceEnv,
+  getDevToken,
 } from '../../scripts/utils.js';
 import {
   createEvent,
@@ -1047,8 +1048,7 @@ export default async function init(el) {
     ...promises,
   ]);
 
-  const sp = new URLSearchParams(window.location.search);
-  const devToken = sp.get('devToken');
+  const devToken = getDevToken();
   if (devToken && getEventServiceEnv() === 'local') {
     buildECCForm(el).then(() => {
       el.classList.remove('loading');

--- a/ecc/scripts/esp-controller.js
+++ b/ecc/scripts/esp-controller.js
@@ -1,5 +1,5 @@
 import { LIBS } from './scripts.js';
-import { getEventServiceEnv, getSecret } from './utils.js';
+import { getDevToken, getEventServiceEnv, getSecret } from './utils.js';
 
 const API_CONFIG = {
   esl: {
@@ -77,8 +77,7 @@ export async function constructRequestOptions(method, body = null) {
   ]);
 
   const headers = new Headers();
-  const sp = new URLSearchParams(window.location.search);
-  const devToken = sp.get('devToken');
+  const devToken = getDevToken();
   const authToken = devToken && getEventServiceEnv() === 'dev' ? devToken : window.adobeIMS?.getAccessToken()?.token;
 
   if (!authToken) window.lana?.log('Error: Failed to get Adobe IMS auth token');
@@ -112,8 +111,7 @@ export async function uploadImage(file, configs, tracker, imageId = null) {
 
   const requestId = await getUuid(new Date().getTime());
   const { host } = API_CONFIG.esp[getEventServiceEnv()];
-  const sp = new URLSearchParams(window.location.search);
-  const devToken = sp.get('devToken');
+  const devToken = getDevToken();
   const authToken = devToken && getEventServiceEnv() === 'dev' ? devToken : window.adobeIMS?.getAccessToken()?.token;
 
   let respJson = null;

--- a/ecc/scripts/utils.js
+++ b/ecc/scripts/utils.js
@@ -4,6 +4,14 @@ const { createTag, getConfig } = await import(`${LIBS}/utils/utils.js`);
 
 let secretCache = [];
 
+export function getDevToken() {
+  const sp = new URLSearchParams(window.location.search);
+  const sessionDevToken = sessionStorage.getItem('devToken');
+  const devToken = sessionDevToken || sp.get('devToken');
+
+  return devToken;
+}
+
 export function getEventServiceEnv() {
   const validEnvs = ['dev', 'stage', 'prod'];
   const { host, search } = window.location;


### PR DESCRIPTION
Leverage sessionStorage to sustain devToken. This change will make navigating on localhost in ECC must more intuitive.

Resolves: [MWPW-162909](https://jira.corp.adobe.com/browse/MWPW-162909)

Test URLs:
- Before: https://dev--ecc-milo--adobecom.hlx.live/drafts/
- After: https://session-dev-token--ecc-milo--adobecom.hlx.live/drafts/

To test the feature, please load up the branch locally and run it against your local ESP and ESL server.
For more information on how to set up ESL and ESP locally, please refer to: https://wiki.corp.adobe.com/display/adobedotcom/Events+Milo+FE+Dev+Wiki#EventsMiloFEDevWiki-Localdevelopmentsetup
