### PR TITLE
[Dev -> Stage] Treat preview absolute path on dashboard too (#313)

### DIFF
--- a/ecc/blocks/ecc-dashboard/ecc-dashboard.js
+++ b/ecc/blocks/ecc-dashboard/ecc-dashboard.js
@@ -294,6 +294,7 @@ function initMoreOptions(props, config, eventObj, row) {
         updateDashboardData(resp, props);
 
         sortData(props, config, { resort: true });
+
         showToast(props, buildToastMsgWithEventTitle(eventObj.title, config['event-unpublished-msg']), { variant: 'positive' });
       });
     } else {
@@ -320,19 +321,33 @@ function initMoreOptions(props, config, eventObj, row) {
 
     if (eventObj.detailPagePath) {
       previewPre.href = (() => {
-        const url = new URL(`${getEventPageHost()}${eventObj.detailPagePath}`);
-        url.searchParams.set('previewMode', 'true');
-        url.searchParams.set('cachebuster', Date.now());
-        url.searchParams.set('timing', +eventObj.localEndTimeMillis - 10);
-        return url.toString();
+        let url;
+
+        try {
+          url = new URL(`${eventObj.detailPagePath}`);
+          url.searchParams.set('previewMode', 'true');
+          url.searchParams.set('cachebuster', Date.now());
+          url.searchParams.set('timing', +eventObj.localEndTimeMillis - 10);
+          return url.toString();
+        } catch (e) {
+          previewPre.classList.add('disabled');
+          return '$';
+        }
       })();
       previewPre.target = '_blank';
       previewPost.href = (() => {
-        const url = new URL(`${getEventPageHost()}${eventObj.detailPagePath}`);
-        url.searchParams.set('previewMode', 'true');
-        url.searchParams.set('cachebuster', Date.now());
-        url.searchParams.set('timing', +eventObj.localEndTimeMillis + 10);
-        return url.toString();
+        let url;
+
+        try {
+          url = new URL(`${eventObj.detailPagePath}`);
+          url.searchParams.set('previewMode', 'true');
+          url.searchParams.set('cachebuster', Date.now());
+          url.searchParams.set('timing', +eventObj.localEndTimeMillis + 10);
+          return url.toString();
+        } catch (e) {
+          previewPost.classList.add('disabled');
+          return '#';
+        }
       })();
       previewPost.target = '_blank';
     } else {


### PR DESCRIPTION
Test URLs:
- Before: https://stage--ecc-milo--adobecom.hlx.live/drafts/
- After: https://dev--ecc-milo--adobecom.hlx.live/drafts/

To test the feature, please load up the branch locally and run it against your local ESP and ESL server.
For more information on how to set up ESL and ESP locally, please refer to: https://wiki.corp.adobe.com/display/adobedotcom/Events+Milo+FE+Dev+Wiki#EventsMiloFEDevWiki-Localdevelopmentsetup
