### PR TITLE
Event Format Inputs locked when ESP has seriesId and cloudType record

### DIFF
--- a/ecc/blocks/event-format-component/controller.js
+++ b/ecc/blocks/event-format-component/controller.js
@@ -68,8 +68,18 @@ export async function onPayloadUpdate(component, props) {
   }
 }
 
-export async function onRespUpdate(_component, _props) {
-  // Do nothing
+export async function onRespUpdate(component, props) {
+  // lock series selector on seriesId given
+
+  if (props.eventDataResp) {
+    const { seriesId, cloudType } = props.eventDataResp;
+
+    const seriesSelect = component.querySelector('#series-select-input');
+    const buSelect = component.querySelector('#bu-select-input');
+
+    if (seriesSelect && !seriesSelect.disabled) seriesSelect.disabled = !!seriesId;
+    if (buSelect && !buSelect.disbaled) buSelect.disabled = !!cloudType;
+  }
 }
 
 async function populateSeriesOptions(props, component) {
@@ -121,7 +131,7 @@ export default async function init(component, props) {
   setTimeout(() => {
     const seriesSelect = component.querySelector('#series-select-input');
 
-    if (seriesSelect.pending || seriesSelect.disabled) {
+    if (seriesSelect.pending) {
       const toastArea = props.el.querySelector('.toast-area');
       if (!toastArea) return;
 


### PR DESCRIPTION
Resolves: [MWPW-NUMBER](https://jira.corp.adobe.com/browse/MWPW-NUMBER)

Test URLs:
- Before: https://dev--ecc-milo--adobecom.hlx.live/drafts/
- After: https://no-series-change--ecc-milo--adobecom.hlx.live/drafts/

To test the feature, please load up the branch locally and run it against your local ESP and ESL server.
For more information on how to set up ESL and ESP locally, please refer to: https://wiki.corp.adobe.com/display/adobedotcom/Events+Milo+FE+Dev+Wiki#EventsMiloFEDevWiki-Localdevelopmentsetup
