### PR TITLE
Dev -> Stage (Squeeze for Jan 15th release)

### DIFF
--- a/ecc/blocks/ecc-dashboard/ecc-dashboard.js
+++ b/ecc/blocks/ecc-dashboard/ecc-dashboard.js
@@ -325,29 +325,36 @@ function initMoreOptions(props, config, eventObj, row) {
 
         try {
           url = new URL(`${eventObj.detailPagePath}`);
+        } catch (e) {
+          url = new URL(`${getEventPageHost()}${eventObj.detailPagePath}`);
+        }
+
+        if (url) {
           url.searchParams.set('previewMode', 'true');
           url.searchParams.set('cachebuster', Date.now());
           url.searchParams.set('timing', +eventObj.localEndTimeMillis - 10);
           return url.toString();
-        } catch (e) {
-          previewPre.classList.add('disabled');
-          return '$';
         }
+        return '#';
       })();
       previewPre.target = '_blank';
+
       previewPost.href = (() => {
         let url;
-
         try {
           url = new URL(`${eventObj.detailPagePath}`);
+        } catch (e) {
+          url = new URL(`${getEventPageHost()}${eventObj.detailPagePath}`);
+        }
+
+        if (url) {
           url.searchParams.set('previewMode', 'true');
           url.searchParams.set('cachebuster', Date.now());
           url.searchParams.set('timing', +eventObj.localEndTimeMillis + 10);
           return url.toString();
-        } catch (e) {
-          previewPost.classList.add('disabled');
-          return '#';
         }
+
+        return '#';
       })();
       previewPost.target = '_blank';
     } else {

--- a/ecc/blocks/event-format-component/controller.js
+++ b/ecc/blocks/event-format-component/controller.js
@@ -68,8 +68,18 @@ export async function onPayloadUpdate(component, props) {
   }
 }
 
-export async function onRespUpdate(_component, _props) {
-  // Do nothing
+export async function onRespUpdate(component, props) {
+  // lock series selector on seriesId given
+
+  if (props.eventDataResp) {
+    const { seriesId, cloudType } = props.eventDataResp;
+
+    const seriesSelect = component.querySelector('#series-select-input');
+    const buSelect = component.querySelector('#bu-select-input');
+
+    if (seriesSelect && !seriesSelect.disabled) seriesSelect.disabled = !!seriesId;
+    if (buSelect && !buSelect.disbaled) buSelect.disabled = !!cloudType;
+  }
 }
 
 async function populateSeriesOptions(props, component) {
@@ -121,7 +131,7 @@ export default async function init(component, props) {
   setTimeout(() => {
     const seriesSelect = component.querySelector('#series-select-input');
 
-    if (seriesSelect.pending || seriesSelect.disabled) {
+    if (seriesSelect.pending) {
       const toastArea = props.el.querySelector('.toast-area');
       if (!toastArea) return;
 

--- a/ecc/blocks/venue-info-component/controller.js
+++ b/ecc/blocks/venue-info-component/controller.js
@@ -213,14 +213,16 @@ export async function onTargetUpdate(component, props) {
   if (component.closest('.fragment')?.classList.contains('hidden')) return;
 
   const venueData = getVenueDataInForm(component);
-
+  const oldVenueData = props.eventDataResp.venue;
   let resp;
-  if (!props.eventDataResp.venue) {
+  if (!oldVenueData) {
     resp = await createVenue(props.eventDataResp.eventId, venueData);
-  } else if (props.eventDataResp.venue.placeId !== venueData.placeId) {
+  } else if (
+    oldVenueData.placeId !== venueData.placeId
+  || (oldVenueData.placeId === venueData.placeId && !oldVenueData.formattedAddress)) {
     resp = await replaceVenue(
       props.eventDataResp.eventId,
-      props.eventDataResp.venue.venueId,
+      oldVenueData.venueId,
       { ...venueData },
     );
 


### PR DESCRIPTION
Series and cloud input lock after first selection
Dashboard Absolute URL backward compatibility

Test URLs:
- Before: https://stage--ecc-milo--adobecom.hlx.live/drafts/
- After: https://dev--ecc-milo--adobecom.hlx.live/drafts/

To test the feature, please load up the branch locally and run it against your local ESP and ESL server.
For more information on how to set up ESL and ESP locally, please refer to: https://wiki.corp.adobe.com/display/adobedotcom/Events+Milo+FE+Dev+Wiki#EventsMiloFEDevWiki-Localdevelopmentsetup
