### PR TITLE
Allow same venue to patch formattedAddress

### DIFF
--- a/ecc/blocks/venue-info-component/controller.js
+++ b/ecc/blocks/venue-info-component/controller.js
@@ -213,14 +213,16 @@ export async function onTargetUpdate(component, props) {
   if (component.closest('.fragment')?.classList.contains('hidden')) return;
 
   const venueData = getVenueDataInForm(component);
-
+  const oldVenueData = props.eventDataResp.venue;
   let resp;
-  if (!props.eventDataResp.venue) {
+  if (!oldVenueData) {
     resp = await createVenue(props.eventDataResp.eventId, venueData);
-  } else if (props.eventDataResp.venue.placeId !== venueData.placeId) {
+  } else if (
+    oldVenueData.placeId !== venueData.placeId
+  || (oldVenueData.placeId === venueData.placeId && !oldVenueData.formattedAddress)) {
     resp = await replaceVenue(
       props.eventDataResp.eventId,
-      props.eventDataResp.venue.venueId,
+      oldVenueData.venueId,
       { ...venueData },
     );
 


### PR DESCRIPTION
Test URLs:
- Before: https://dev--ecc-milo--adobecom.hlx.live/drafts/
- After: https://venue-backward-compatibility--ecc-milo--adobecom.hlx.live/drafts/

To test the feature, please load up the branch locally and run it against your local ESP and ESL server.
For more information on how to set up ESL and ESP locally, please refer to: https://wiki.corp.adobe.com/display/adobedotcom/Events+Milo+FE+Dev+Wiki#EventsMiloFEDevWiki-Localdevelopmentsetup
