### PR TITLE
Preview link error: Capturing Absolute URL vs Relative URL

### DIFF
--- a/ecc/blocks/form-handler/form-handler.js
+++ b/ecc/blocks/form-handler/form-handler.js
@@ -870,7 +870,15 @@ function updateCtas(props) {
     if (a.classList.contains('preview-btns')) {
       const testTime = a.classList.contains('pre-event') ? +props.eventDataResp.localEndTimeMillis - 10 : +props.eventDataResp.localEndTimeMillis + 10;
       if (eventDataResp.detailPagePath) {
-        a.href = `${eventDataResp.detailPagePath}?previewMode=true&cachebuster=${Date.now()}&timing=${testTime}`;
+        let previewUrl;
+
+        try {
+          previewUrl = new URL(eventDataResp.detailPagePath).href;
+        } catch (e) {
+          previewUrl = `${getEventPageHost()}${eventDataResp.detailPagePath}`;
+        }
+
+        a.href = `${previewUrl}?previewMode=true&cachebuster=${Date.now()}&timing=${testTime}`;
         a.classList.remove('preview-not-ready');
       }
     }


### PR DESCRIPTION
Test URLs:
- Before: https://dev--ecc-milo--adobecom.hlx.live/drafts/
- After: https://domain-fix--ecc-milo--adobecom.hlx.live/drafts/

To test the feature, please load up the branch locally and run it against your local ESP and ESL server.
For more information on how to set up ESL and ESP locally, please refer to: https://wiki.corp.adobe.com/display/adobedotcom/Events+Milo+FE+Dev+Wiki#EventsMiloFEDevWiki-Localdevelopmentsetup
