### PR TITLE
MWPW-146930 - Rollout tool plugin

### DIFF
--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -82,6 +82,18 @@
       "includePaths": [
         "**.docx**"
       ]
+    },
+    {
+      "containerId": "tools",
+      "id": "rollout",
+      "title": "Rollout",
+      "environments": [ "preview" ],
+      "isPalette": true,
+      "passReferrer": true,
+      "passConfig": true,
+      "url": "https://milo.adobe.com/tools/rollout",
+      "includePaths": [ "**.docx**", "**.xlsx**" ],
+      "paletteRect": "top: 40%; left: 50%; transform: translate(-50%,-50%); height: 350px; width: 500px; overflow: hidden; border-radius: 15px; box-shadow: 0 20px 35px 0px rgba(0, 0, 0, 0.5);"
     }
   ]
 }

--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -1,4 +1,5 @@
 {
+  "project": "ECC",
   "plugins": [
     {
       "id": "library",


### PR DESCRIPTION
Adding option in sidekick to rollout files directly to geos. This plugin will do some basic calculation and form a url. On selection of the environment, the user will be taken to the Loc V3 project config page with some options (sent as part of the parameter) pre-selected.

Resolves: [MWPW-146930](https://jira.corp.adobe.com/browse/MWPW-146930)

**Test URLs:**
- Before: https://dev--ecc-milo--adobecom.hlx.page/drafts/?martech=off
- After: https://rollout--ecc-milo--raga-adbe-gh.hlx.page/drafts/?martech=off
