### PR TITLE
Adding automated PR description placeholder job

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,8 +3,8 @@ Describe your specific features or fixes and provide a preview link for the feat
 Resolves: [MWPW-NUMBER](https://jira.corp.adobe.com/browse/MWPW-NUMBER)
 
 Test URLs:
-- Before: https://<BASE_BRANCH>--ecc-milo--adobecom.hlx.live/drafts/
-- After: https://<TARGET_BRANCH>--ecc-milo--adobecom.hlx.live/drafts/
+- Before: https://<BASE_BRANCH>--ecc-milo--adobecom.aem.live/drafts/
+- After: https://<TARGET_BRANCH>--ecc-milo--adobecom.aem.live/drafts/
 
 To test the feature, please load up the branch locally and run it against your local ESP and ESL server.
 For more information on how to set up ESL and ESP locally, please refer to: [FE Dev Wiki](https://wiki.corp.adobe.com/display/adobedotcom/Events+Milo+FE+Dev+Wiki#EventsMiloFEDevWiki-Localdevelopmentsetup)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,8 +3,8 @@ Describe your specific features or fixes and provide a preview link for the feat
 Resolves: [MWPW-NUMBER](https://jira.corp.adobe.com/browse/MWPW-NUMBER)
 
 Test URLs:
-- Before: https://main--ecc-milo--adobecom.hlx.live/drafts/
-- After: https://<branch>--ecc-milo--adobecom.hlx.live/drafts/
+- Before: https://<BASE_BRANCH>--ecc-milo--adobecom.hlx.live/drafts/
+- After: https://<TARGET_BRANCH>--ecc-milo--adobecom.hlx.live/drafts/
 
 To test the feature, please load up the branch locally and run it against your local ESP and ESL server.
-For more information on how to set up ESL and ESP locally, please refer to: https://wiki.corp.adobe.com/display/adobedotcom/Events+Milo+FE+Dev+Wiki#EventsMiloFEDevWiki-Localdevelopmentsetup
+For more information on how to set up ESL and ESP locally, please refer to: [FE Dev Wiki](https://wiki.corp.adobe.com/display/adobedotcom/Events+Milo+FE+Dev+Wiki#EventsMiloFEDevWiki-Localdevelopmentsetup)

--- a/.github/workflows/update-pro-description.yml
+++ b/.github/workflows/update-pro-description.yml
@@ -14,13 +14,13 @@ jobs:
         with:
           script: |
             const pr = context.payload.pull_request;
-            return { base: pr.base.ref, head: pr.head.ref };
+            return JSON.stringify({ base: pr.base.ref, head: pr.head.ref });
 
       - name: Update PR Description
         uses: actions/github-script@v6
         with:
           script: |
-            const prDetails = core.getInput('pr-details');
+            const prDetails = JSON.parse(core.getInput('pr-details'));
             const baseBranch = prDetails.base;
             const targetBranch = prDetails.head;
 

--- a/.github/workflows/update-pro-description.yml
+++ b/.github/workflows/update-pro-description.yml
@@ -12,17 +12,18 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
-            const pr = context.payload.pull_request;
-            const baseBranch = pr.base.ref;
-            const targetBranch = pr.head.ref;
+            if (context.payload.pull_request.body.includes('<BASE_BRANCH>')) {
+              const baseBranch = context.payload.pull_request.base.ref;
+              const targetBranch = context.payload.pull_request.head.ref;
 
-            const updatedBody = context.payload.pull_request.body
-              .replace('<BASE_BRANCH>', baseBranch)
-              .replace('<TARGET_BRANCH>', targetBranch);
+              const updatedBody = context.payload.pull_request.body
+                .replace('<BASE_BRANCH>', baseBranch)
+                .replace('<TARGET_BRANCH>', targetBranch);
 
-            github.rest.pulls.update({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.payload.pull_request.number,
-              body: updatedBody,
-            });
+              github.rest.pulls.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.payload.pull_request.number,
+                body: updatedBody,
+              });
+            }

--- a/.github/workflows/update-pro-description.yml
+++ b/.github/workflows/update-pro-description.yml
@@ -2,7 +2,7 @@ name: Update PR Description
 
 on:
   pull_request:
-    types: [opened, edited]
+    types: [opened]
 
 jobs:
   update-description:

--- a/.github/workflows/update-pro-description.yml
+++ b/.github/workflows/update-pro-description.yml
@@ -14,6 +14,7 @@ jobs:
         with:
           script: |
             const pr = context.payload.pull_request;
+            console.log(pr.base.ref, pr.head.ref);
             return JSON.stringify({ base: pr.base.ref, head: pr.head.ref });
 
       - name: Update PR Description

--- a/.github/workflows/update-pro-description.yml
+++ b/.github/workflows/update-pro-description.yml
@@ -15,16 +15,12 @@ jobs:
           script: |
             const pr = context.payload.pull_request;
             return { base: pr.base.ref, head: pr.head.ref };
-        result-encoding: string
-
-      - name: Debug PR Details
-        run: echo "PR Details: ${{ steps.pr-details.outputs.result }}"
 
       - name: Update PR Description
         uses: actions/github-script@v6
         with:
           script: |
-            const prDetails = JSON.parse(core.getInput('pr-details'));
+            const prDetails = core.getInput('pr-details');
             const baseBranch = prDetails.base;
             const targetBranch = prDetails.head;
 

--- a/.github/workflows/update-pro-description.yml
+++ b/.github/workflows/update-pro-description.yml
@@ -2,7 +2,7 @@ name: Update PR Description
 
 on:
   pull_request:
-    types: [opened, edited]
+    types: [opened, synchronize, reopened]
 
 jobs:
   update-description:

--- a/.github/workflows/update-pro-description.yml
+++ b/.github/workflows/update-pro-description.yml
@@ -2,7 +2,7 @@ name: Update PR Description
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened]
 
 jobs:
   update-description:

--- a/.github/workflows/update-pro-description.yml
+++ b/.github/workflows/update-pro-description.yml
@@ -1,0 +1,34 @@
+name: Update PR Description
+
+on:
+  pull_request:
+    types: [opened, edited]
+
+jobs:
+  update-description:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get PR Details
+        id: pr
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            return { base: pr.base.ref, head: pr.head.ref };
+
+      - name: Update PR Description
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const { base, head } = JSON.parse(core.getInput('pr-details'));
+            const updatedBody = context.payload.pull_request.body
+              .replace('<BASE_BRANCH>', base)
+              .replace('<TARGET_BRANCH>', head);
+            github.rest.pulls.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              body: updatedBody,
+            });
+        env:
+          pr-details: ${{ steps.pr.outputs.result }}

--- a/.github/workflows/update-pro-description.yml
+++ b/.github/workflows/update-pro-description.yml
@@ -2,29 +2,31 @@ name: Update PR Description
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, edited]
 
 jobs:
   update-description:
     runs-on: ubuntu-latest
     steps:
       - name: Get PR Details
-        id: pr
+        id: pr-details
         uses: actions/github-script@v6
         with:
           script: |
             const pr = context.payload.pull_request;
-            console.log('PR Details in get:', pr.base.ref, pr.head.ref);
             return { base: pr.base.ref, head: pr.head.ref };
+        result-encoding: string
+
+      - name: Debug PR Details
+        run: echo "PR Details: ${{ steps.pr-details.outputs.result }}"
 
       - name: Update PR Description
         uses: actions/github-script@v6
         with:
           script: |
-            console.log('core input', core.getInput('pr-details'));
-            const prDetails = core.getInput('pr-details');
-            const baseBranch = prDetails['base'];
-            const targetBranch = prDetails['head'];
+            const prDetails = JSON.parse(core.getInput('pr-details'));
+            const baseBranch = prDetails.base;
+            const targetBranch = prDetails.head;
 
             const updatedBody = context.payload.pull_request.body
               .replace('<BASE_BRANCH>', baseBranch)
@@ -37,4 +39,4 @@ jobs:
               body: updatedBody,
             });
         env:
-          pr-details: ${{ steps.pr.outputs.result }}
+          pr-details: ${{ steps.pr-details.outputs.result }}

--- a/.github/workflows/update-pro-description.yml
+++ b/.github/workflows/update-pro-description.yml
@@ -8,22 +8,13 @@ jobs:
   update-description:
     runs-on: ubuntu-latest
     steps:
-      - name: Get PR Details
-        id: pr
-        uses: actions/github-script@v6
-        with:
-          script: |
-            const pr = context.payload.pull_request;
-            return JSON.stringify({ base: pr.base.ref, head: pr.head.ref });
-
       - name: Update PR Description
         uses: actions/github-script@v6
         with:
           script: |
-            console.log('PR Details:', context.payload.pull_request);
-            const prDetails = JSON.parse(core.getInput('pr-details'));
-            const baseBranch = prDetails.base;
-            const targetBranch = prDetails.head;
+            const pr = context.payload.pull_request;
+            const baseBranch = pr.base.ref;
+            const targetBranch = pr.head.ref;
 
             const updatedBody = context.payload.pull_request.body
               .replace('<BASE_BRANCH>', baseBranch)
@@ -35,5 +26,3 @@ jobs:
               pull_number: context.payload.pull_request.number,
               body: updatedBody,
             });
-        env:
-          pr-details: ${{ steps.pr.outputs.result }}

--- a/.github/workflows/update-pro-description.yml
+++ b/.github/workflows/update-pro-description.yml
@@ -14,6 +14,7 @@ jobs:
         with:
           script: |
             const pr = context.payload.pull_request;
+            console.log(pr);
             return JSON.stringify({ base: pr.base.ref, head: pr.head.ref });
 
       - name: Update PR Description

--- a/.github/workflows/update-pro-description.yml
+++ b/.github/workflows/update-pro-description.yml
@@ -14,6 +14,7 @@ jobs:
         with:
           script: |
             const pr = context.payload.pull_request;
+            console.log('PR Details in get:', pr.base.ref, pr.head.ref);
             return { base: pr.base.ref, head: pr.head.ref };
 
       - name: Update PR Description
@@ -21,6 +22,7 @@ jobs:
         with:
           script: |
             const prDetails = core.getInput('pr-details');
+            console.log('PR Details in update:', prDetails);
             const baseBranch = prDetails['base'];
             const targetBranch = prDetails['head'];
 

--- a/.github/workflows/update-pro-description.yml
+++ b/.github/workflows/update-pro-description.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
-            const prDetails = JSON.parse(core.getInput('pr-details'));
+            const prDetails = core.getInput('pr-details');
             const baseBranch = prDetails.base;
             const targetBranch = prDetails.head;
 

--- a/.github/workflows/update-pro-description.yml
+++ b/.github/workflows/update-pro-description.yml
@@ -9,32 +9,30 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get PR Details
-        id: pr-details
+        id: pr
         uses: actions/github-script@v6
         with:
           script: |
             const pr = context.payload.pull_request;
-            const details = {
-              base: pr.base.ref,
-              head: pr.head.ref
-            };
-            core.setOutput('base', details.base);
-            core.setOutput('head', details.head);
+            return JSON.stringify({ base: pr.base.ref, head: pr.head.ref });
 
       - name: Update PR Description
         uses: actions/github-script@v6
         with:
           script: |
-            const baseBranch = '${{ steps.pr-details.outputs.base }}';
-            const targetBranch = '${{ steps.pr-details.outputs.head }}';
+            const prDetails = JSON.parse(core.getInput('pr-details'));
+            const baseBranch = prDetails.base;
+            const targetBranch = prDetails.head;
 
             const updatedBody = context.payload.pull_request.body
               .replace('<BASE_BRANCH>', baseBranch)
               .replace('<TARGET_BRANCH>', targetBranch);
 
-            await github.rest.pulls.update({
+            github.rest.pulls.update({
               owner: context.repo.owner,
               repo: context.repo.repo,
               pull_number: context.payload.pull_request.number,
-              body: updatedBody
+              body: updatedBody,
             });
+        env:
+          pr-details: ${{ steps.pr.outputs.result }}

--- a/.github/workflows/update-pro-description.yml
+++ b/.github/workflows/update-pro-description.yml
@@ -14,27 +14,27 @@ jobs:
         with:
           script: |
             const pr = context.payload.pull_request;
-            console.log(pr.base.ref, pr.head.ref);
-            return { base: pr.base.ref, head: pr.head.ref };
+            const details = {
+              base: pr.base.ref,
+              head: pr.head.ref
+            };
+            core.setOutput('base', details.base);
+            core.setOutput('head', details.head);
 
       - name: Update PR Description
         uses: actions/github-script@v6
         with:
           script: |
-            const prDetails = core.getInput('pr-details');
-            console.log(prDetails);
-            const baseBranch = prDetails.base;
-            const targetBranch = prDetails.head;
+            const baseBranch = '${{ steps.pr-details.outputs.base }}';
+            const targetBranch = '${{ steps.pr-details.outputs.head }}';
 
             const updatedBody = context.payload.pull_request.body
               .replace('<BASE_BRANCH>', baseBranch)
               .replace('<TARGET_BRANCH>', targetBranch);
 
-            github.rest.pulls.update({
+            await github.rest.pulls.update({
               owner: context.repo.owner,
               repo: context.repo.repo,
               pull_number: context.payload.pull_request.number,
-              body: updatedBody,
+              body: updatedBody
             });
-        env:
-          pr-details: ${{ steps.pr-details.outputs.result }}

--- a/.github/workflows/update-pro-description.yml
+++ b/.github/workflows/update-pro-description.yml
@@ -14,6 +14,7 @@ jobs:
         with:
           script: |
             const pr = context.payload.pull_request;
+            console.log(pr.base.ref, pr.head.ref);
             return { base: pr.base.ref, head: pr.head.ref };
 
       - name: Update PR Description
@@ -21,6 +22,7 @@ jobs:
         with:
           script: |
             const prDetails = core.getInput('pr-details');
+            console.log(prDetails);
             const baseBranch = prDetails.base;
             const targetBranch = prDetails.head;
 

--- a/.github/workflows/update-pro-description.yml
+++ b/.github/workflows/update-pro-description.yml
@@ -20,6 +20,7 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
+            console.log('PR Details:', context.payload.pull_request);
             const prDetails = JSON.parse(core.getInput('pr-details'));
             const baseBranch = prDetails.base;
             const targetBranch = prDetails.head;

--- a/.github/workflows/update-pro-description.yml
+++ b/.github/workflows/update-pro-description.yml
@@ -14,16 +14,20 @@ jobs:
         with:
           script: |
             const pr = context.payload.pull_request;
-            return { base: pr.base.ref, head: pr.head.ref };
+            return JSON.stringify({ base: pr.base.ref, head: pr.head.ref });
 
       - name: Update PR Description
         uses: actions/github-script@v6
         with:
           script: |
-            const { base, head } = JSON.parse(core.getInput('pr-details'));
+            const prDetails = JSON.parse(core.getInput('pr-details'));
+            const baseBranch = prDetails.base;
+            const targetBranch = prDetails.head;
+
             const updatedBody = context.payload.pull_request.body
-              .replace('<BASE_BRANCH>', base)
-              .replace('<TARGET_BRANCH>', head);
+              .replace('<BASE_BRANCH>', baseBranch)
+              .replace('<TARGET_BRANCH>', targetBranch);
+
             github.rest.pulls.update({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/update-pro-description.yml
+++ b/.github/workflows/update-pro-description.yml
@@ -21,8 +21,8 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
+            console.log('core input', core.getInput('pr-details'));
             const prDetails = core.getInput('pr-details');
-            console.log('PR Details in update:', prDetails);
             const baseBranch = prDetails['base'];
             const targetBranch = prDetails['head'];
 

--- a/.github/workflows/update-pro-description.yml
+++ b/.github/workflows/update-pro-description.yml
@@ -2,7 +2,7 @@ name: Update PR Description
 
 on:
   pull_request:
-    types: [opened]
+    types: [opened, synchronize, reopened]
 
 jobs:
   update-description:

--- a/.github/workflows/update-pro-description.yml
+++ b/.github/workflows/update-pro-description.yml
@@ -14,8 +14,7 @@ jobs:
         with:
           script: |
             const pr = context.payload.pull_request;
-            console.log(pr.base.ref, pr.head.ref);
-            return JSON.stringify({ base: pr.base.ref, head: pr.head.ref });
+            return { base: pr.base.ref, head: pr.head.ref };
 
       - name: Update PR Description
         uses: actions/github-script@v6

--- a/.github/workflows/update-pro-description.yml
+++ b/.github/workflows/update-pro-description.yml
@@ -14,7 +14,6 @@ jobs:
         with:
           script: |
             const pr = context.payload.pull_request;
-            console.log(pr);
             return JSON.stringify({ base: pr.base.ref, head: pr.head.ref });
 
       - name: Update PR Description

--- a/.github/workflows/update-pro-description.yml
+++ b/.github/workflows/update-pro-description.yml
@@ -14,13 +14,13 @@ jobs:
         with:
           script: |
             const pr = context.payload.pull_request;
-            return JSON.stringify({ base: pr.base.ref, head: pr.head.ref });
+            return { base: pr.base.ref, head: pr.head.ref };
 
       - name: Update PR Description
         uses: actions/github-script@v6
         with:
           script: |
-            const prDetails = JSON.parse(core.getInput('pr-details'));
+            const prDetails = core.getInput('pr-details');
             const baseBranch = prDetails.base;
             const targetBranch = prDetails.head;
 

--- a/.github/workflows/update-pro-description.yml
+++ b/.github/workflows/update-pro-description.yml
@@ -21,8 +21,8 @@ jobs:
         with:
           script: |
             const prDetails = core.getInput('pr-details');
-            const baseBranch = prDetails.base;
-            const targetBranch = prDetails.head;
+            const baseBranch = prDetails['base'];
+            const targetBranch = prDetails['head'];
 
             const updatedBody = context.payload.pull_request.body
               .replace('<BASE_BRANCH>', baseBranch)


### PR DESCRIPTION
This is so that we never have to update the test url domain anymore

Resolves: [MWPW-NUMBER](https://jira.corp.adobe.com/browse/MWPW-NUMBER)

Test URLs:
- Before: https://dev--ecc-milo--adobecom.hlx.live/drafts/
- After: https://pr-description-job--ecc-milo--adobecom.hlx.live/drafts/

To test the feature, please load up the branch locally and run it against your local ESP and ESL server.
For more information on how to set up ESL and ESP locally, please refer to: https://wiki.corp.adobe.com/display/adobedotcom/Events+Milo+FE+Dev+Wiki#EventsMiloFEDevWiki-Localdevelopmentsetup
