### PR TITLE
FE Venue validation

### DIFF
--- a/ecc/blocks/venue-info-component/controller.js
+++ b/ecc/blocks/venue-info-component/controller.js
@@ -173,7 +173,7 @@ function initAutocomplete(el, props) {
 }
 
 export async function onSubmit(component, props) {
-  // do nothing. Depend on onEventUpdate cb.
+  // do nothing. Depend on onTargetUpdate cb.
 }
 
 export async function onPayloadUpdate(component, props) {
@@ -221,6 +221,12 @@ export async function onTargetUpdate(component, props) {
   if (component.closest('.fragment')?.classList.contains('hidden')) return;
 
   const venueData = getVenueDataInForm(component);
+
+  if (!venueData.placeId) {
+    component.dispatchEvent(new CustomEvent('show-error-toast', { detail: { error: { message: 'Please select a valid venue.' } }, bubbles: true, composed: true }));
+    return;
+  }
+
   const oldVenueData = props.eventDataResp.venue;
   let resp;
   if (!oldVenueData) {

--- a/ecc/blocks/venue-info-component/venue-info-component.js
+++ b/ecc/blocks/venue-info-component/venue-info-component.js
@@ -18,7 +18,7 @@ function decorateSWCTextField(row, extraOptions) {
     maxCharNum = maxLengthCol.querySelector('strong')?.textContent.trim();
   }
 
-  const isRequired = attrTextEl?.textContent.trim().endsWith('*');
+  const isRequired = extraOptions.required || attrTextEl?.textContent.trim().endsWith('*');
 
   const input = createTag('sp-textfield', { ...extraOptions, class: 'venue-info-text text-input', placeholder: text });
 
@@ -54,7 +54,7 @@ function buildAdditionalInfo(row) {
 
 function buildLocationInputGrid(row) {
   const locationDetailsWrapper = createTag('div', { class: 'location-wrapper' });
-  const placeIdInput = createTag('input', { id: 'google-place-id', type: 'hidden' });
+  const placeIdInput = createTag('input', { id: 'google-place-id', type: 'hidden', required: true });
   const placeLATInput = createTag('input', { id: 'google-place-lat', type: 'hidden' });
   const placeLNGInput = createTag('input', { id: 'google-place-lng', type: 'hidden' });
   const gmtOffsetInput = createTag('input', { id: 'google-place-gmt-offset', type: 'hidden' });
@@ -95,6 +95,7 @@ export default function init(el) {
           quiet: true,
           size: 'xl',
           readonly: true,
+          required: true,
         });
         break;
       case 3:


### PR DESCRIPTION
Prevents EMC form first step submission without a placeId

Resolves: [MWPW-167074](https://jira.corp.adobe.com/browse/MWPW-167074)

Test URLs:
- Before: https://dev--ecc-milo--adobecom.aem.live/drafts/
- After: https://venue-validation--ecc-milo--adobecom.aem.live/drafts/

To test the feature, please load up the branch locally and run it against your local ESP and ESL server.
For more information on how to set up ESL and ESP locally, please refer to: [FE Dev Wiki](https://wiki.corp.adobe.com/display/adobedotcom/Events+Milo+FE+Dev+Wiki#EventsMiloFEDevWiki-Localdevelopmentsetup)
