### PR TITLE
QA fixes 2/4

### DIFF
--- a/ecc/blocks/form-handler/form-handler.js
+++ b/ecc/blocks/form-handler/form-handler.js
@@ -1,3 +1,6 @@
+/* eslint-disable no-async-promise-executor */
+/* eslint-disable no-promise-executor-return */
+/* eslint-disable no-await-in-loop */
 import { LIBS } from '../../scripts/scripts.js';
 import {
   getIcon,
@@ -556,53 +559,46 @@ function buildPreviewLoadingDialog(props, targetHref, poll) {
   dialog.innerHTML = '';
 
   createTag('h1', { slot: 'heading' }, 'Generating your preview...', { parent: dialog });
-  createTag('p', {}, 'This usually takes 10-30 seconds, but it might take up to 10 minutes in rare cases. Please wait, and the preview will open in a new tab when it’s ready.', { parent: dialog });
-  createTag('p', {}, '<strong>Note: Please make sure pop-up is allowed in your browser settings.</strong>', { parent: dialog });
+  createTag('p', {}, 'This usually takes 10-30 seconds, but in rare cases it might take up to 10 minutes. Please wait, and the preview will open in a new tab when it’s ready.', { parent: dialog });
+  createTag('p', {}, '<strong>Note: Please ensure pop-ups are allowed in your browser.</strong>', { parent: dialog });
+
   const style = createTag('style', {}, `
     @keyframes progress-bar-indeterminate {
-      0% {
-        transform: translateX(-100%);
-      }
-      50% {
-        transform: translateX(0%);
-      }
-      100% {
-        transform: translateX(200%);
-      }
+      0% { transform: translateX(-100%); }
+      50% { transform: translateX(0%); }
+      100% { transform: translateX(200%); }
     }
   `);
 
-  // Create the progress bar container
   const progressBar = createTag('div', {
     style: `
-    position: relative;
-    width: 100%;
-    height: 8px;
-    background: #e6e6e6;
-    border-radius: 4px;
-    overflow: hidden;
-    margin-bottom: 1rem;
+      position: relative;
+      width: 100%;
+      height: 8px;
+      background: #e6e6e6;
+      border-radius: 4px;
+      overflow: hidden;
+      margin-bottom: 1rem;
     `,
   });
 
-  // Create the progress bar indicator
   const progressBarIndicator = createTag('div', {
     style: `
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 50%;
-    height: 100%;
-    background: #1473e6;
-    transform: translateX(0);
-    animation: progress-bar-indeterminate 1.5s linear infinite;
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 50%;
+      height: 100%;
+      background: #1473e6;
+      transform: translateX(0);
+      animation: progress-bar-indeterminate 1.5s linear infinite;
     `,
   });
 
-  // Append the elements to the shadow root
   progressBar.appendChild(progressBarIndicator);
   dialog.appendChild(style);
   dialog.appendChild(progressBar);
+
   const buttonContainer = createTag('div', { class: 'button-container' }, '', { parent: dialog });
   const seePreviewButton = createTag('sp-button', { variant: 'secondary', slot: 'button', id: 'see-preview' }, 'Go to preview page now', { parent: buttonContainer });
   const cancelButton = createTag('sp-button', { variant: 'cta', slot: 'button', id: 'cancel-preview' }, 'Cancel', { parent: buttonContainer });
@@ -610,16 +606,18 @@ function buildPreviewLoadingDialog(props, targetHref, poll) {
   underlay.open = true;
 
   seePreviewButton.addEventListener('click', () => {
+    seePreviewButton.disabled = true;
+    cancelButton.disabled = true;
     window.open(targetHref);
     closeDialog(props);
-    if (poll.interval) clearInterval(poll.interval);
-    poll.resolve();
+    poll.cancel();
   });
 
   cancelButton.addEventListener('click', () => {
+    seePreviewButton.disabled = true;
+    cancelButton.disabled = true;
     closeDialog(props);
-    if (poll.interval) clearInterval(poll.interval);
-    poll.resolve();
+    poll.cancel();
   });
 
   return dialog;
@@ -693,35 +691,46 @@ async function validatePreview(props, cta) {
   };
 
   return new Promise((resolve) => {
-    const interval = setInterval(async () => {
-      try {
-        retryCount += 1;
-        const metadataJson = await getNonProdPreviewDataById(props);
-
-        if (metadataJson && modificationTimeMatch(metadataJson)) {
-          clearInterval(interval);
-          closeDialog(props);
-          window.open(previewHref);
-          resolve();
-        } else if (!metadataJson || retryCount >= 30) {
-          clearInterval(interval);
-          buildPreviewLoadingFailedDialog(props, previewHref);
-          window.lana?.log('Error: Failed to fetch metadata');
-          resolve();
-        }
-      } catch (error) {
-        window.lana?.log('Error in interval fetch:', error);
-        clearInterval(interval);
-        resolve();
-      }
-    }, Math.floor(Math.random() * (2000 - 1000 + 1)) + 1000);
+    let cancelled = false;
+    let isResolved = false;
 
     const poll = {
-      interval,
-      resolve,
+      cancel: () => {
+        if (isResolved) return;
+        isResolved = true;
+        cancelled = true;
+        resolve();
+      },
     };
 
     buildPreviewLoadingDialog(props, previewHref, poll);
+
+    (async function pollLoop() {
+      while (!cancelled && retryCount < 30) {
+        retryCount += 1;
+        const delay = Math.floor(Math.random() * (2000 - 1000 + 1)) + 1000;
+        await new Promise((r) => setTimeout(r, delay));
+        if (cancelled) break;
+        try {
+          const metadataJson = await getNonProdPreviewDataById(props);
+          if (metadataJson && modificationTimeMatch(metadataJson)) {
+            closeDialog(props);
+            window.open(previewHref);
+            poll.cancel();
+            return;
+          }
+        } catch (error) {
+          window.lana?.log('Error in sequential poll:', error);
+          break;
+        }
+      }
+
+      if (!cancelled) {
+        buildPreviewLoadingFailedDialog(props, previewHref);
+        window.lana?.log('Error: Failed to fetch metadata');
+      }
+      poll.cancel();
+    }());
   });
 }
 

--- a/ecc/blocks/form-handler/form-handler.js
+++ b/ecc/blocks/form-handler/form-handler.js
@@ -559,7 +559,7 @@ function buildPreviewLoadingDialog(props, targetHref, poll) {
   dialog.innerHTML = '';
 
   createTag('h1', { slot: 'heading' }, 'Generating your preview...', { parent: dialog });
-  createTag('p', {}, 'This usually takes 10-30 seconds, but in rare cases it might take up to 10 minutes. Please wait, and the preview will open in a new tab when it’s ready.', { parent: dialog });
+  createTag('p', {}, 'This usually takes less than a minute, but in rare cases it might take up to 10 minutes. Please wait, and the preview will open in a new tab when it’s ready.', { parent: dialog });
   createTag('p', {}, '<strong>Note: Please ensure pop-ups are allowed in your browser.</strong>', { parent: dialog });
 
   const style = createTag('style', {}, `
@@ -706,7 +706,7 @@ async function validatePreview(props, cta) {
     buildPreviewLoadingDialog(props, previewHref, poll);
 
     (async function pollLoop() {
-      while (!cancelled && retryCount < 30) {
+      while (!cancelled && retryCount < 60) {
         retryCount += 1;
         const delay = Math.floor(Math.random() * (2000 - 1000 + 1)) + 1000;
         await new Promise((r) => setTimeout(r, delay));

--- a/ecc/components/cmc/cmc.js
+++ b/ecc/components/cmc/cmc.js
@@ -33,11 +33,10 @@ export default class CloudManagementConsole extends LitElement {
     this.selectedTags = new Set();
     this.pendingChanges = false;
     this.config = { 'series-dashboard-location': '/ecc/dashboard/t3/series' };
-    this.toastState = {
-      open: false,
-      variant: 'info',
-      text: '',
-    };
+  }
+
+  firstUpdated() {
+    this.toast = this.shadowRoot.querySelector('sp-toast');
   }
 
   static getParsedTitle(tag) {
@@ -192,11 +191,7 @@ export default class CloudManagementConsole extends LitElement {
     const newCloudData = await updateCloud(this.currentCloud, { ...cloudData, ...payload });
 
     if (newCloudData && !newCloudData.error) {
-      this.toastState = {
-        open: true,
-        variant: 'positive',
-        text: 'Changes saved',
-      };
+      if (this.toast) this.toast.open = true;
     }
   }
 
@@ -271,7 +266,7 @@ export default class CloudManagementConsole extends LitElement {
       </div>
     </div>
     <div class="action-bar">
-        <sp-toast ?open=${this.toastState.open} variant=${this.toastState.variant} size="m" timeout="6000">${this.toastState.text}</sp-toast>
+        <sp-toast variant="positive" size="m" timeout="6000">Changes saved</sp-toast>
         <sp-button variant="secondary" size="l" ?disabled=${!this.pendingChanges || !this.currentCloud} @click=${() => {
           const fullSavedTags = this.savedTags[this.currentCloud]?.map((tag) => this.deepGetTagByTagID(tag.tagID)) || [];
           this.selectedTags = new Set(fullSavedTags); this.pendingChanges = false;


### PR DESCRIPTION
- Tweaked the preview generation script to fire only sequentially and extend the polling period.
- Fixed the CMC success toast one-time use issue

Resolves:
[MWPW-167018](https://jira.corp.adobe.com/browse/MWPW-167018)
[MWPW-164370](https://jira.corp.adobe.com/browse/MWPW-164370)

Test URLs:
- Before: https://dev--ecc-milo--adobecom.aem.live/drafts/
- After: https://qa-fixes-2-4--ecc-milo--adobecom.aem.live/drafts/

To test the feature, please load up the branch locally and run it against your local ESP and ESL server.
For more information on how to set up ESL and ESP locally, please refer to: [FE Dev Wiki](https://wiki.corp.adobe.com/display/adobedotcom/Events+Milo+FE+Dev+Wiki#EventsMiloFEDevWiki-Localdevelopmentsetup)
