### PR TITLE
Tags are now grouped under shared parent paths

### DIFF
--- a/ecc/blocks/cmc/cmc.js
+++ b/ecc/blocks/cmc/cmc.js
@@ -1,5 +1,6 @@
 import { LIBS } from '../../scripts/scripts.js';
-import { getCaasTags, getClouds } from '../../scripts/esp-controller.js';
+import { getClouds } from '../../scripts/esp-controller.js';
+import { getCaasTags } from '../../scripts/caas.js';
 import {
   buildNoAccessScreen,
   generateToolTip,

--- a/ecc/blocks/event-topics-component/controller.js
+++ b/ecc/blocks/event-topics-component/controller.js
@@ -2,14 +2,35 @@
 
 import { LIBS } from '../../scripts/scripts.js';
 import { getCloud } from '../../scripts/esp-controller.js';
-
-const { createTag } = await import(`${LIBS}/utils/utils.js`);
+import { deepGetTagByTagID, getCaasTags } from '../../scripts/caas.js';
 
 const SUPPORTED_TOPIC_TYPES = ['product', 'industry'];
 const addSvg = '<svg xmlns="http://www.w3.org/2000/svg" height="18" viewBox="0 0 18 18" width="18"><defs><style>.fill-shaded {fill: #464646;}</style></defs><title>S Add 18 N</title><rect id="Canvas" fill="#ff13dc" opacity="0" width="18" height="18" /><path class="fill-shaded" d="M14.5,8H10V3.5A.5.5,0,0,0,9.5,3h-1a.5.5,0,0,0-.5.5V8H3.5a.5.5,0,0,0-.5.5v1a.5.5,0,0,0,.5.5H8v4.5a.5.5,0,0,0,.5.5h1a.5.5,0,0,0,.5-.5V10h4.5a.5.5,0,0,0,.5-.5v-1A.5.5,0,0,0,14.5,8Z" /></svg>';
 const checkSvg = '<svg xmlns="http://www.w3.org/2000/svg" height="18" viewBox="0 0 18 18" width="18"><defs><style>.fill-white {fill: #ffffff;}</style></defs><title>S Checkmark 18 N</title><rect id="Canvas" fill="#ffffff" opacity="0" width="18" height="18" /><path class="fill-white" d="M15.656,3.8625l-.7275-.5665a.5.5,0,0,0-.7.0875L7.411,12.1415,4.0875,8.8355a.5.5,0,0,0-.707,0L2.718,9.5a.5.5,0,0,0,0,.707l4.463,4.45a.5.5,0,0,0,.75-.0465L15.7435,4.564A.5.5,0,0,0,15.656,3.8625Z" /></svg>';
 
+function getFullParentName(tagId, caasTags) {
+  const targetTag = deepGetTagByTagID(tagId, caasTags);
+
+  if (!targetTag) return '';
+
+  const parentIds = [];
+
+  const tagIds = targetTag.tagID.split('/');
+  while (tagIds.length > 1) {
+    tagIds.pop();
+    parentIds.push(tagIds.join('/'));
+  }
+
+  const parentNames = parentIds.map((id) => deepGetTagByTagID(id, caasTags).title).reverse().join(' ');
+  return parentNames || 'Base Tags';
+}
+
 async function buildTopicsCheckboxes(el, cloudType) {
+  const [{ createTag }, cassTags] = await Promise.all([
+    import(`${LIBS}/utils/utils.js`),
+    getCaasTags(),
+  ]);
+
   if (!el || !cloudType) return;
 
   const cw = el.querySelector('.checkbox-wrapper') || createTag('div', { class: 'checkbox-wrapper' }, '', { parent: el });
@@ -23,18 +44,41 @@ async function buildTopicsCheckboxes(el, cloudType) {
   const { cloudTags } = currentCloudData;
 
   if (cloudTags) {
+    const pathNameMap = new Map();
+
     cloudTags.forEach((tag) => {
       const { name, caasId } = tag;
 
       if (!caasId || !name) return;
 
-      const button = createTag('sp-action-button', { name, toggles: true, 'data-value': JSON.stringify(tag) }, name, { parent: cw });
+      const path = caasId.split('/');
+      const pathNameKey = path.length > 1 ? path.slice(0, -1).join('-').replace('caas:', '') : 'base-tags';
+
+      const button = createTag('sp-action-button', { name, toggles: true, 'data-value': JSON.stringify(tag) }, name);
       const checkboxIcon = createTag('sp-icon', { size: 's', slot: 'icon' }, addSvg);
+
+      const parentName = getFullParentName(caasId, cassTags.namespaces.caas);
       button.prepend(checkboxIcon);
 
       button.addEventListener('change', () => {
         checkboxIcon.innerHTML = button.selected ? checkSvg : addSvg;
       });
+
+      if (pathNameMap.has(pathNameKey)) {
+        pathNameMap.set(pathNameKey, [...pathNameMap.get(pathNameKey), tag]);
+
+        const groupWrapper = cw.querySelector(`.tags-group[data-name="${pathNameKey}"] .tags-group-wrapper`);
+        if (!groupWrapper) return;
+
+        groupWrapper.append(button);
+      } else {
+        pathNameMap.set(pathNameKey, [name]);
+
+        const tagsGroup = createTag('div', { class: 'tags-group', 'data-name': pathNameKey }, '', { parent: cw });
+        createTag('h3', { class: 'tags-group-heading' }, parentName, { parent: tagsGroup });
+        const groupWrapper = createTag('div', { class: 'tags-group-wrapper' }, '', { parent: tagsGroup });
+        groupWrapper.append(button);
+      }
     });
   } else {
     createTag('sp-label', { size: 'm' }, 'No tags found for this Cloud', { parent: cw });

--- a/ecc/blocks/event-topics-component/event-topics-component.css
+++ b/ecc/blocks/event-topics-component/event-topics-component.css
@@ -2,10 +2,22 @@
   font-size: var(--type-heading-s-size);
 }
 
-.event-topics-component .checkbox-wrapper {
+.event-topics-component .tags-group {
+  width: 100%;
+  padding-bottom: 40px;
+  margin-bottom: 16px;
+  border-bottom: 2px solid var(--stroke-color-divider);
+}
+
+.event-topics-component .tags-group .tags-group-wrapper {
   display: flex;
   flex-wrap: wrap;
   gap: 12px;
+}
+
+.event-topics-component .tags-group:last-of-type {
+  padding-bottom: 0;
+  border-bottom: none;
 }
 
 .event-topics-component sp-progress-circle {

--- a/ecc/blocks/product-promotion-component/controller.js
+++ b/ecc/blocks/product-promotion-component/controller.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-unused-vars */
-import { getCaasTags } from '../../scripts/esp-controller.js';
+import { getCaasTags } from '../../scripts/caas.js';
 import { handlize } from '../../scripts/utils.js';
 
 export function onSubmit(component, props) {

--- a/ecc/scripts/caas.js
+++ b/ecc/scripts/caas.js
@@ -1,0 +1,54 @@
+export const getCaasTags = (() => {
+  let cache;
+  let promise;
+
+  return () => {
+    if (cache) {
+      return cache;
+    }
+
+    if (!promise) {
+      promise = fetch('https://www.adobe.com/chimera-api/tags')
+        .then((resp) => {
+          if (resp.ok) {
+            return resp.json();
+          }
+
+          throw new Error('Failed to load tags');
+        })
+        .then((data) => {
+          cache = data;
+          return data;
+        })
+        .catch((err) => {
+          window.lana?.log(`Failed to load products map JSON. Error: ${err}`);
+          throw err;
+        });
+    }
+
+    return promise;
+  };
+})();
+
+export function deepGetTagByPath(pathArray, index, tags = {}) {
+  let currentTag = tags;
+
+  pathArray.forEach((path, i) => {
+    if (i <= index && path) {
+      currentTag = currentTag.tags[path];
+    }
+  });
+
+  return currentTag;
+}
+
+export function deepGetTagByTagID(tagID, tags = {}) {
+  const tagIDs = tagID.replace('caas:', '').split('/');
+  let currentTag = tags;
+
+  tagIDs.forEach((tag) => {
+    currentTag = currentTag.tags[tag];
+  });
+
+  return currentTag;
+}

--- a/ecc/scripts/esp-controller.js
+++ b/ecc/scripts/esp-controller.js
@@ -3,38 +3,6 @@ import { getEventServiceEnv, getSecret, signIn } from './utils.js';
 import { getUser, userHasAccessToBU, userHasAccessToEvent, userHasAccessToSeries } from './profile.js';
 import { API_CONFIG, ALLOWED_HOSTS } from './constants.js';
 
-export const getCaasTags = (() => {
-  let cache;
-  let promise;
-
-  return () => {
-    if (cache) {
-      return cache;
-    }
-
-    if (!promise) {
-      promise = fetch('https://www.adobe.com/chimera-api/tags')
-        .then((resp) => {
-          if (resp.ok) {
-            return resp.json();
-          }
-
-          throw new Error('Failed to load tags');
-        })
-        .then((data) => {
-          cache = data;
-          return data;
-        })
-        .catch((err) => {
-          window.lana?.log(`Failed to load products map JSON. Error: ${err}`);
-          throw err;
-        });
-    }
-
-    return promise;
-  };
-})();
-
 export function waitForAdobeIMS() {
   return new Promise((resolve) => {
     const checkIMS = () => {


### PR DESCRIPTION
Group tags by their shared parent path titles
<img width="845" alt="Screenshot 2025-03-11 at 11 21 04 PM" src="https://github.com/user-attachments/assets/cc987816-b109-442e-89fc-442018473aa0" />

Resolves: [MWPW-163225](https://jira.corp.adobe.com/browse/MWPW-163225)

Test URLs:
- Before: https://dev--ecc-milo--adobecom.aem.live/drafts/
- After: https://tags-grouping--ecc-milo--adobecom.aem.live/drafts/

To test the feature, please load up the branch locally and run it against your local ESP and ESL server.
For more information on how to set up ESL and ESP locally, please refer to: [FE Dev Wiki](https://wiki.corp.adobe.com/display/adobedotcom/Events+Milo+FE+Dev+Wiki#EventsMiloFEDevWiki-Localdevelopmentsetup)
