### PR TITLE
MWPW-164213 : Adding support for private event 

### DIFF
--- a/ecc/blocks/event-info-component/controller.js
+++ b/ecc/blocks/event-info-component/controller.js
@@ -314,6 +314,7 @@ function dateTimeStringToTimestamp(dateString, timeString) {
 export function onSubmit(component, props) {
   if (component.closest('.fragment')?.classList.contains('hidden')) return;
 
+  const isPrivate = component.querySelector('#private-event').checked;
   const title = component.querySelector('#info-field-event-title').value;
   const description = component.querySelector('#info-field-event-description').value;
   const datePicker = component.querySelector('#event-info-date-picker');
@@ -338,6 +339,7 @@ export function onSubmit(component, props) {
     localStartTimeMillis,
     localEndTimeMillis,
     timezone,
+    isPrivate,
   };
 
   props.payload = { ...props.payload, ...eventInfo };
@@ -554,6 +556,7 @@ export default async function init(component, props) {
     localStartTime,
     localEndTime,
     timezone,
+    isPrivate,
   } = eventData;
 
   if (title
@@ -573,6 +576,7 @@ export default async function init(component, props) {
       selectedEndDate: parseFormatedDate(localEndDate),
     });
 
+    component.querySelector('#private-event').checked = isPrivate || false;
     component.querySelector('#info-field-event-title').value = title || '';
     component.querySelector('#info-field-event-description').value = description || '';
     changeInputValue(startTime, 'value', `${localStartTime}` || '');

--- a/ecc/blocks/event-info-component/event-info-component.css
+++ b/ecc/blocks/event-info-component/event-info-component.css
@@ -297,6 +297,18 @@
   z-index: -1;
 }
 
+.event-info-component .private-event-toggle-wrapper {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.event-info-component .title-container {
+  display: flex;
+  gap: 16px;
+  flex-direction: column;
+}
+
 @media screen and (min-width: 900px) {
   .event-info-component .date-time-row {
     flex-direction: row;

--- a/ecc/blocks/event-info-component/event-info-component.js
+++ b/ecc/blocks/event-info-component/event-info-component.js
@@ -5,9 +5,13 @@ import {
   decorateTextfield,
   decorateTextarea,
   miloReplaceKey,
+  addTooltipToEl,
 } from '../../scripts/utils.js';
 
 const { createTag } = await import(`${LIBS}/utils/utils.js`);
+
+const privateEventString = 'Set as a private event';
+const privateEventToolTip = 'By setting this to private, your event won\'t be publicly found online or published to the events hub.';
 
 function buildDatePicker(column) {
   column.classList.add('date-picker');
@@ -102,6 +106,13 @@ function decorateDateTimeFields(row) {
   });
 }
 
+function addPrivateEventToggle(el) {
+  el.classList.add('title-container');
+  const div = createTag('div', { class: 'private-event-toggle-wrapper' }, '', { parent: el });
+  createTag('sp-switch', { id: 'private-event', checked: false, size: 'xl' }, privateEventString, { parent: div });
+  addTooltipToEl(privateEventToolTip, div);
+}
+
 export default function init(el) {
   el.classList.add('form-component');
 
@@ -110,6 +121,7 @@ export default function init(el) {
     switch (i) {
       case 0:
         generateToolTip(r);
+        addPrivateEventToggle(r);
         break;
       case 1:
         await decorateTextfield(r, { id: 'info-field-event-title' }, await miloReplaceKey('duplicate-event-title-error'));

--- a/ecc/blocks/event-info-component/event-info-component.js
+++ b/ecc/blocks/event-info-component/event-info-component.js
@@ -109,7 +109,7 @@ function decorateDateTimeFields(row) {
 function addPrivateEventToggle(el) {
   el.classList.add('title-container');
   const div = createTag('div', { class: 'private-event-toggle-wrapper' }, '', { parent: el });
-  createTag('sp-switch', { id: 'private-event', checked: false, size: 'xl' }, privateEventString, { parent: div });
+  createTag('sp-checkbox', { id: 'private-event', size: 'xl' }, privateEventString, { parent: div });
   addTooltipToEl(privateEventToolTip, div);
 }
 

--- a/ecc/blocks/form-handler/form-handler.css
+++ b/ecc/blocks/form-handler/form-handler.css
@@ -285,6 +285,10 @@
   flex-direction: row-reverse;
 }
 
+.form-handler .form-component > div:first-of-type {
+  margin-bottom: 32px;
+}
+
 .form-handler .form-component > div:first-of-type > div > h2 {
   font-size: var(--type-heading-xl-size);
   line-height: var(--type-heading-xl-lh);
@@ -296,7 +300,6 @@
   align-items: center;
   gap: 8px;
   margin: 0;
-  margin-bottom: 32px;
 }
 
 .form-handler .main-frame .section:first-of-type h2 {

--- a/ecc/blocks/form-handler/form-handler.js
+++ b/ecc/blocks/form-handler/form-handler.js
@@ -83,6 +83,7 @@ const SPECTRUM_COMPONENTS = [
   'icon',
   'action-button',
   'progress-circle',
+  'switch',
 ];
 
 export function buildErrorMessage(props, resp) {

--- a/ecc/scripts/constants.js
+++ b/ecc/scripts/constants.js
@@ -79,4 +79,5 @@ export const EVENT_DATA_FILTER = {
   published: { type: 'boolean', cloneable: false, submittable: true },
   creationTime: { type: 'string', cloneable: false, submittable: true },
   modificationTime: { type: 'string', cloneable: false, submittable: true },
+  isPrivate: { type: 'boolean', cloneable: true, submittable: true },
 };


### PR DESCRIPTION
Describe your specific features or fixes and provide a preview link for the feature being incorporated
Adding support for private event as per spec https://www.figma.com/design/ZviEcqGf6VKc3WAmKOuZQ3/branch/ienZcdCN0zkoSfDxTH3Wdi/Tier3_Events_Phase2_UX_SSOT_DESIGN?node-id=15009-7105&m=dev

Resolves: [MWPW-164213](https://jira.corp.adobe.com/browse/MWPW-164213)

Test URLs:

Before: https://dev--ecc-milo--adobecom.aem.live/drafts/
After: https://revert-413-revert-is-private--ecc-milo--adobecom.aem.live/drafts/
To test the feature, please load up the branch locally and run it against your local ESP and ESL server.
For more information on how to set up ESL and ESP locally, please refer to: [FE Dev Wiki](https://wiki.corp.adobe.com/display/adobedotcom/Events+Milo+FE+Dev+Wiki#EventsMiloFEDevWiki-Localdevelopmentsetup)