### PR TITLE
Revert "Making isPrivate checkbox readonly after first save"

### DIFF
--- a/ecc/blocks/event-info-component/controller.js
+++ b/ecc/blocks/event-info-component/controller.js
@@ -491,12 +491,7 @@ function prefillFields(component, props, eventData) {
   if (isValidAttribute(timezone)) changeInputValue(component.querySelector('#time-zone-select-input'), 'value', `${timezone}` || '');
   if (isValidAttribute(defaultLocale)) changeInputValue(languagePicker, 'value', defaultLocale || props.locale);
   if (isValidAttribute(enTitle)) changeInputValue(enTitleInput, 'value', enTitle || '');
-  if (isValidAttribute(isPrivate)) {
-    changeInputValue(isPrivateInput, 'checked', isPrivate || false);
-    if (isPrivate) {
-      isPrivateInput.setAttribute('disabled', 'true');
-    }
-  }
+  if (isValidAttribute(isPrivate)) changeInputValue(isPrivateInput, 'checked', isPrivate || false);
 
   if (title && localStartDate && eventData.eventId) {
     BlockMediator.set('eventDupMetrics', {


### PR DESCRIPTION

Describe your specific features or fixes and provide a preview link for the feature being incorporated
Revert "Making isPrivate checkbox readonly after first save"

Reverts: [MWPW-171074](https://jira.corp.adobe.com/browse/MWPW-171074)

Test URLs:

Before: https://dev--ecc-milo--adobecom.aem.live/drafts/
After: https://revert-446-gbajaj-mwpw171074--ecc-milo--adobecom.aem.live/drafts/
To test the feature, please load up the branch locally and run it against your local ESP and ESL server.
For more information on how to set up ESL and ESP locally, please refer to: [FE Dev Wiki](https://wiki.corp.adobe.com/display/adobedotcom/Events+Milo+FE+Dev+Wiki#EventsMiloFEDevWiki-Localdevelopmentsetup)Reverts adobecom/ecc-milo#446