### PR TITLE
Fixing a typo in CMC causing the pending change state to not reset correctly

### DIFF
--- a/ecc/components/cmc/cmc.js
+++ b/ecc/components/cmc/cmc.js
@@ -154,6 +154,10 @@ export default class CloudManagementConsole extends LitElement {
     return Array.from(this.selectedTags);
   }
 
+  getSelectedLocales() {
+    return Array.from(this.selectedLocales);
+  }
+
   switchCloudType(cloudType) {
     if (cloudType === this.currentCloud) return;
     const savedCloudTags = this.savedTags[cloudType] || [];
@@ -179,7 +183,7 @@ export default class CloudManagementConsole extends LitElement {
 
   async save() {
     this.savedTags[this.currentCloud] = this.getSelectedTags();
-    this.savedLocales[this.currentCloud] = this.selectedLocales;
+    this.savedLocales[this.currentCloud] = this.getSelectedLocales();
 
     this.togglePendingChanges();
 


### PR DESCRIPTION
Resolves: [MWPW-171608](https://jira.corp.adobe.com/browse/MWPW-171608)

Test URLs:
- Before: https://dev--ecc-milo--adobecom.aem.live/drafts/
- After: https://lang-pool-state-fix--ecc-milo--adobecom.aem.live/drafts/

To test the feature, please load up the branch locally and run it against your local ESP and ESL server.
For more information on how to set up ESL and ESP locally, please refer to: [FE Dev Wiki](https://wiki.corp.adobe.com/display/adobedotcom/Events+Milo+FE+Dev+Wiki#EventsMiloFEDevWiki-Localdevelopmentsetup)
