### PR TITLE
Fix legacy niche data access of localeData

### DIFF
--- a/ecc/blocks/form-handler/data-handler.js
+++ b/ecc/blocks/form-handler/data-handler.js
@@ -159,22 +159,6 @@ export function getFilteredCachedResponse() {
   return filteredResponse;
 }
 
-export function getLocalizedResponseData(props) {
-  const response = getFilteredCachedResponse(props.locale);
-  return {
-    ...response,
-    ...response.localizations?.[props.locale] || {},
-  };
-}
-
-export function getLocalizedPayloadData(props) {
-  const payload = getFilteredCachedPayload(props.locale);
-  return {
-    ...payload,
-    ...payload.localizations?.[props.locale] || {},
-  };
-}
-
 export default function getJoinedData(locale) {
   const filteredResponse = getFilteredCachedResponse(locale);
   const filteredPayload = getFilteredCachedPayload(locale);

--- a/ecc/blocks/form-handler/form-handler.js
+++ b/ecc/blocks/form-handler/form-handler.js
@@ -33,11 +33,11 @@ import RTETiptap from '../../components/rte-tiptap/rte-tiptap.js';
 import getJoinedData, {
   setPayloadCache,
   setResponseCache,
-  getLocalizedResponseData,
   setRemoveCache,
 } from './data-handler.js';
 import { getUser, initProfileLogicTree, userHasAccessToBU, userHasAccessToEvent, userHasAccessToSeries } from '../../scripts/profile.js';
 import CustomSearch from '../../components/custom-search/custom-search.js';
+import { getAttribute } from '../../scripts/data-utils.js';
 
 const { createTag } = await import(`${LIBS}/utils/utils.js`);
 const { decorateButtons } = await import(`${LIBS}/utils/decorate.js`);
@@ -118,9 +118,8 @@ export function buildErrorMessage(props, resp) {
     } else if (errorMessage) {
       if (resp.status === 409 || resp.error.message === 'Request to ESP failed: {"message":"Event update invalid, event has been modified since last fetch"}') {
         const toast = createTag('sp-toast', { open: true, variant: 'negative' }, 'The event has been updated by a different session since your last save.', { parent: toastArea });
-        const localeData = getLocalizedResponseData(props);
         const url = new URL(window.location.href);
-        url.searchParams.set('eventId', localeData.eventId);
+        url.searchParams.set('eventId', getAttribute(props.eventDataResp, 'eventId', props.locale));
 
         createTag('sp-button', {
           slot: 'action',
@@ -447,10 +446,10 @@ function updateDashboardLink(props) {
   const url = new URL(dashboardLink.href);
   if (url.searchParams.has('eventId')) return;
 
-  const localeData = getLocalizedResponseData(props);
-  if (!localeData.eventId) return;
+  const eventId = getAttribute(props.eventDataResp, 'eventId', props.locale);
+  if (!eventId) return;
 
-  url.searchParams.set('newEventId', localeData.eventId);
+  url.searchParams.set('newEventId', eventId);
   dashboardLink.href = url.toString();
 }
 
@@ -473,8 +472,7 @@ async function saveEvent(props, toPublish = false) {
     }
   };
 
-  const localeData = getLocalizedResponseData(props);
-  if (props.currentStep === 0 && !localeData.eventId) {
+  if (props.currentStep === 0 && !getAttribute(props.eventDataResp, 'eventId', props.locale)) {
     resp = await createEvent(getJoinedData(props.locale), props.locale);
     if (!resp.error && resp) {
       const newEventData = await getEvent(resp.eventId);
@@ -809,16 +807,15 @@ function initFormCtas(props) {
           e.preventDefault();
           toggleBtnsSubmittingState(true);
 
-          const localeData = getLocalizedResponseData(props);
-
-          if (!localeData.eventId) {
+          const eventId = getAttribute(props.eventDataResp, 'eventId', props.locale);
+          if (!eventId) {
             buildErrorMessage(props, { error: { message: 'Event ID is not found' } });
             toggleBtnsSubmittingState(false);
             return;
           }
 
           const resp = await previewEvent(
-            localeData.eventId,
+            eventId,
             getJoinedData(props.locale),
           );
 
@@ -1049,11 +1046,11 @@ function toggleSections(props) {
 }
 
 export async function handleSubmit(props) {
-  const localeData = getLocalizedResponseData(props);
-  if (!localeData.eventId) return;
+  const eventId = getAttribute(props.eventDataResp, 'eventId', props.locale);
+  if (!eventId) return;
 
   const url = new URL(window.location.href);
-  url.searchParams.set('newEventId', localeData.eventId);
+  url.searchParams.set('newEventId', eventId);
   window.location.href = url;
 }
 


### PR DESCRIPTION
A small portion of the code is looking for eventId through outdated helper function. This PR should fix that.

Test URLs:
- Before: https://dev--ecc-milo--adobecom.aem.live/drafts/
- After: https://fix-locale-data-access--ecc-milo--adobecom.aem.live/drafts/

To test the feature, please load up the branch locally and run it against your local ESP and ESL server.
For more information on how to set up ESL and ESP locally, please refer to: [FE Dev Wiki](https://wiki.corp.adobe.com/display/adobedotcom/Events+Milo+FE+Dev+Wiki#EventsMiloFEDevWiki-Localdevelopmentsetup)
