### PR TITLE
Remove locale based filtering for Speaker

### DIFF
--- a/ecc/blocks/profile-component/controller.js
+++ b/ecc/blocks/profile-component/controller.js
@@ -104,8 +104,7 @@ export async function onPayloadUpdate(component, props) {
     if (props.payload.seriesId && props.payload.seriesId !== container.seriesId) {
       container.setAttribute('seriesId', props.payload.seriesId);
       const { speakers } = await getSpeakers(props.payload.seriesId);
-      const filterdSpeakers = speakers.filter((speaker) => speaker.localizations && typeof speaker.localizations === 'object' && props.locale in speaker.localizations);
-      container.searchdata = filterdSpeakers ?? [];
+      container.searchdata = speakers ?? [];
     }
 
     if (props.locale) {

--- a/ecc/components/profile-container/profile-container.js
+++ b/ecc/components/profile-container/profile-container.js
@@ -36,9 +36,7 @@ export default class ProfileContainer extends LitElement {
 
   reloadSearchData = async () => {
     const spResp = await getSpeakers(this.seriesId);
-    // eslint-disable-next-line max-len
-    const filterdSpeakers = spResp.speakers.filter((speaker) => speaker.localizations && typeof speaker.localizations === 'object' && this.locale in speaker.localizations);
-    if (filterdSpeakers) this.searchdata = filterdSpeakers;
+    if (spResp) this.searchdata = spResp.speakers ?? [];
   };
 
   updateProfile(index, profile) {


### PR DESCRIPTION
Test URLs:
- Before: https://dev--ecc-milo--adobecom.aem.live/drafts/
- After: https://remove-speaker-filter--ecc-milo--adobecom.aem.live/drafts/

To test the feature, please load up the branch locally and run it against your local ESP and ESL server.
For more information on how to set up ESL and ESP locally, please refer to: [FE Dev Wiki](https://wiki.corp.adobe.com/display/adobedotcom/Events+Milo+FE+Dev+Wiki#EventsMiloFEDevWiki-Localdevelopmentsetup)
