### PR TITLE
Populate prefilled data in RTE outputs

### DIFF
--- a/ecc/blocks/event-info-component/controller.js
+++ b/ecc/blocks/event-info-component/controller.js
@@ -447,6 +447,7 @@ function prefillFields(component, props, eventData) {
   const eventTitleInput = component.querySelector('#info-field-event-title');
   const eventDescription = component.querySelector('#info-field-event-description');
   const eventDescriptionRTE = component.querySelector('#event-info-description-rte');
+  const eventDescriptionRTEOutput = component.querySelector('#event-info-description-rte-output');
   const startTimeInput = component.querySelector('#time-picker-start-time');
   const startAmpmInput = component.querySelector('#ampm-picker-start-time');
   const endTimeInput = component.querySelector('#time-picker-end-time');
@@ -472,7 +473,10 @@ function prefillFields(component, props, eventData) {
 
   if (isValidAttribute(title)) eventTitleInput.value = title;
   if (isValidAttribute(description)) eventDescription.value = description;
-  if (isValidAttribute(richDescription)) eventDescriptionRTE.content = richDescription;
+  if (isValidAttribute(richDescription)) {
+    eventDescriptionRTE.content = richDescription;
+    eventDescriptionRTEOutput.value = richDescription;
+  }
   if (isValidAttribute(localStartDate)) datePicker.dataset.startDate = localStartDate;
   if (isValidAttribute(localEndDate)) datePicker.dataset.endDate = localEndDate;
   if (isValidAttribute(localStartTime)) {

--- a/ecc/blocks/registration-details-component/controller.js
+++ b/ecc/blocks/registration-details-component/controller.js
@@ -47,7 +47,7 @@ function prefillFields(component, props) {
   const disbleWaitlistEl = component.querySelector('#registration-disable-waitlist');
   const allowGuestRegistrationEl = component.querySelector('#allow-guest-registration');
   const descriptionEl = component.querySelector('#rsvp-description-rte');
-
+  const descriptionRTEOutput = component.querySelector('#rsvp-description-rte-output');
   const eventData = props.eventDataResp;
 
   if (eventData) {
@@ -59,7 +59,10 @@ function prefillFields(component, props) {
 
     if (attendeeLimitEl && attendeeLimit) attendeeLimitEl.value = attendeeLimit;
     if (disbleWaitlistEl) disbleWaitlistEl.checked = !allowWaitlisting;
-    if (descriptionEl && rsvpDescription) descriptionEl.content = rsvpDescription;
+    if (descriptionEl && rsvpDescription) {
+      descriptionEl.content = rsvpDescription;
+      descriptionRTEOutput.value = rsvpDescription;
+    }
     if (hostEmail) {
       if (contactHostEl) contactHostEl.checked = true;
       if (hostEmailEl) hostEmailEl.value = hostEmail;


### PR DESCRIPTION
Fixing an edge case where an immediate save after returning flow will clear RTE values

Test URLs:
- Before: https://dev--ecc-milo--adobecom.aem.live/drafts/
- After: https://fix-rte-outputs--ecc-milo--adobecom.aem.live/drafts/

To test the feature, please load up the branch locally and run it against your local ESP and ESL server.
For more information on how to set up ESL and ESP locally, please refer to: [FE Dev Wiki](https://wiki.corp.adobe.com/display/adobedotcom/Events+Milo+FE+Dev+Wiki#EventsMiloFEDevWiki-Localdevelopmentsetup)
