### PR TITLE
Trigger speaker save for complete profile ui on event save

### DIFF
--- a/ecc/components/profile-container/profile-container.js
+++ b/ecc/components/profile-container/profile-container.js
@@ -58,6 +58,17 @@ export default class ProfileContainer extends LitElement {
     return firstName && lastName && title;
   }
 
+  async saveAllProfiles() {
+    const profileComponents = this.shadowRoot.querySelectorAll('profile-ui');
+    await Promise.all(Array.from(profileComponents).map(async (profileComponent) => {
+      const { profile } = profileComponent;
+      if (!profile.speakerId) {
+        return profileComponent.saveProfile();
+      }
+      return null;
+    }));
+  }
+
   getProfiles() {
     return this.profiles
       .filter((p) => !p.isPlaceholder && !isEmptyObject(p) && this.isValidSpeaker(p))

--- a/ecc/scripts/data-utils.js
+++ b/ecc/scripts/data-utils.js
@@ -180,6 +180,9 @@ export function splitLocalizableFields(data, filter, locale) {
 export async function getSpeakerPayload(speakerData, locale, seriesId) {
   if (!speakerData) return speakerData;
 
+  // Remove empty social links
+  speakerData.socialLinks = speakerData.socialLinks.filter((sm) => sm.link !== '');
+
   let existingSpeakerPayload = {};
   if (speakerData.speakerId) {
     existingSpeakerPayload = await getSpeaker(seriesId, speakerData.speakerId);


### PR DESCRIPTION
Saving the Host & Speakers step will save all of the filled individual profile UIs.

Resolves: [MWPW-NUMBER](https://jira.corp.adobe.com/browse/MWPW-NUMBER)

Test URLs:
- Before: https://<BASE_BRANCH>--ecc-milo--adobecom.aem.live/drafts/
- After: https://<TARGET_BRANCH>--ecc-milo--adobecom.aem.live/drafts/

To test the feature, please load up the branch locally and run it against your local ESP and ESL server.
For more information on how to set up ESL and ESP locally, please refer to: [FE Dev Wiki](https://wiki.corp.adobe.com/display/adobedotcom/Events+Milo+FE+Dev+Wiki#EventsMiloFEDevWiki-Localdevelopmentsetup)
