### PR TITLE
add missing flag for old URL protection

### DIFF
--- a/ecc/scripts/data-utils.js
+++ b/ecc/scripts/data-utils.js
@@ -78,6 +78,7 @@ export const EVENT_DATA_FILTER = {
   creationTime: { type: 'string', localizable: false, cloneable: false, submittable: true },
   modificationTime: { type: 'string', localizable: false, cloneable: false, submittable: true },
   isPrivate: { type: 'boolean', localizable: false, cloneable: true, submittable: true },
+  useLegacyDetailPagePath: { type: 'boolean', localizable: false, cloneable: false, submittable: true },
   video: { type: 'object', localizable: false, cloneable: true, submittable: true, ref: VIDEO_DATA_REF_FILTER },
   registration: { type: 'object', localizable: false, cloneable: true, submittable: true, ref: REGISTRATION_DATA_REF_FILTER },
 };


### PR DESCRIPTION
Test URLs:
- Before: https://dev--ecc-milo--adobecom.aem.live/drafts/
- After: https://respect-legacy-flag--ecc-milo--adobecom.aem.live/drafts/

To test the feature, please load up the branch locally and run it against your local ESP and ESL server.
For more information on how to set up ESL and ESP locally, please refer to: [FE Dev Wiki](https://wiki.corp.adobe.com/display/adobedotcom/Events+Milo+FE+Dev+Wiki#EventsMiloFEDevWiki-Localdevelopmentsetup)
