### PR TITLE
force adobeid env for internal dev domain

### DIFF
--- a/ecc/scripts/scripts.js
+++ b/ecc/scripts/scripts.js
@@ -75,6 +75,20 @@ export function decorateArea(area = document) {
   });
 }
 
+function getAdobeid() {
+  const adobeid = {
+    onTokenExpired: () => {
+      window.location.reload();
+    },
+  };
+
+  if (window.location.hostname === 'events-internal.dev.adobe.com') {
+    adobeid.environment = 'stage';
+  }
+
+  return adobeid;
+}
+
 const locales = {
   '': { ietf: 'en-US', tk: 'jdq5hay.css' },
   br: { ietf: 'pt-BR', tk: 'inq1xob.css' },
@@ -111,11 +125,7 @@ const CONFIG = {
   // fallbackRouting: 'off',
   decorateArea,
   locales,
-  adobeid: {
-    onTokenExpired: () => {
-      window.locaton.reload();
-    },
-  },
+  adobeid: getAdobeid(),
 };
 
 const RELEASE_VERSION = 'T3-25.20';


### PR DESCRIPTION
Fix the issue reported by myself here:
https://adobedotcom.slack.com/archives/C12TA9N8N/p1747230861571679

Test URLs:
- Before: https://dev--ecc-milo--adobecom.aem.live/drafts/
- After: https://dev-pri-domain--ecc-milo--adobecom.aem.live/drafts/

To test the feature, please load up the branch locally and run it against your local ESP and ESL server.
For more information on how to set up ESL and ESP locally, please refer to: [FE Dev Wiki](https://wiki.corp.adobe.com/display/adobedotcom/Events+Milo+FE+Dev+Wiki#EventsMiloFEDevWiki-Localdevelopmentsetup)
