### PR TITLE
Filter series dropdown cross referencing template supported event types

### DIFF
--- a/ecc/blocks/event-format-component/controller.js
+++ b/ecc/blocks/event-format-component/controller.js
@@ -17,6 +17,12 @@ function filterSeries(series, currentCloud) {
   });
 }
 
+async function getTemplates() {
+  return fetch('/ecc/system/series-templates.json')
+    .then((res) => res.json())
+    .then((data) => data.data);
+}
+
 function prepopulateTimeZone(component) {
   const currentTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
   if (!currentTimeZone) return;
@@ -61,6 +67,7 @@ function initStepLock(component) {
 }
 
 async function populateSeriesOptions(props, component) {
+  const currentEventType = props.payload.eventType;
   const seriesSelect = component.querySelector('#series-select-input');
   if (!seriesSelect) return;
 
@@ -68,7 +75,7 @@ async function populateSeriesOptions(props, component) {
   seriesSelect.disabled = false;
   changeInputValue(seriesSelect, 'value', null);
 
-  const series = await getSeriesForUser();
+  const [series, templates] = await Promise.all([getSeriesForUser(), getTemplates()]);
   if (series.error) {
     seriesSelect.pending = false;
     seriesSelect.disabled = true;
@@ -79,10 +86,15 @@ async function populateSeriesOptions(props, component) {
   existingOptions.forEach((opt) => opt.remove());
 
   const filteredSeries = filterSeries(series, component.dataset.cloudType);
-
   filteredSeries.forEach((val) => {
     if (!val.seriesId || !val.seriesName) return;
     if (val.seriesStatus?.toLowerCase() !== 'published') return;
+
+    const seriesTemplate = templates.find((t) => t['template-path'] === val.templateId);
+    if (!seriesTemplate) return;
+
+    const supportedEventType = seriesTemplate['supported-event-type'];
+    if (supportedEventType !== currentEventType) return;
 
     const opt = createTag('sp-menu-item', { value: val.seriesId }, val.seriesName);
     seriesSelect.append(opt);


### PR DESCRIPTION
From the authoring side, this required an additional column 'supported-event-type' in the templates sheet.
The series dropdown will now also fetch the sheet, and check if the current event type is supported by a series as one of the filtering metrics.

Test URLs:
- Before: https://<BASE_BRANCH>--ecc-milo--adobecom.aem.live/drafts/
- After: https://<TARGET_BRANCH>--ecc-milo--adobecom.aem.live/drafts/

To test the feature, please load up the branch locally and run it against your local ESP and ESL server.
For more information on how to set up ESL and ESP locally, please refer to: [FE Dev Wiki](https://wiki.corp.adobe.com/display/adobedotcom/Events+Milo+FE+Dev+Wiki#EventsMiloFEDevWiki-Localdevelopmentsetup)
