### PR TITLE
List of QA fixes

### DIFF
--- a/ecc/blocks/ecc-dashboard/ecc-dashboard.js
+++ b/ecc/blocks/ecc-dashboard/ecc-dashboard.js
@@ -367,7 +367,9 @@ function initMoreOptions(props, config, eventObj, row) {
       e.preventDefault();
       const payload = { ...eventObj };
       const cloneTitle = `${getAttribute(eventObj, 'title', payload.defaultLocale || 'en-US')} - copy`;
+      const cloneEnTitle = `${getAttribute(eventObj, 'enTitle', payload.defaultLocale || 'en-US')} - copy`;
       setEventAttribute(payload, 'title', cloneTitle, payload.defaultLocale || 'en-US');
+      setEventAttribute(payload, 'enTitle', cloneEnTitle, payload.defaultLocale || 'en-US');
       toolBox.remove();
       row.classList.add('pending');
       const newEventJSON = await createEvent({ ...cloneFilter(payload), published: false }, payload.defaultLocale || 'en-US');

--- a/ecc/blocks/marketo-integration-component/controller.js
+++ b/ecc/blocks/marketo-integration-component/controller.js
@@ -12,7 +12,13 @@ export async function onPayloadUpdate(component, props) {
 
 export async function onRespUpdate(component, props) {
   if (props.eventDataResp) {
-    const { marketoIntegration } = props.eventDataResp;
+    const { marketoIntegration, eventId } = props.eventDataResp;
+
+    const eventTypeSelect = component.querySelector('#marketo-event-type-select-input');
+    const salesforceCampaignIdInput = component.querySelector('#marketo-salesforce-campaign-id-input');
+    const mczProgramNameInput = component.querySelector('#marketo-mcz-program-name-input');
+    const coMarketingPartnerInput = component.querySelector('#marketo-co-marketing-partner-input');
+    const eventPoiInput = component.querySelector('#marketo-event-poi-input');
 
     if (marketoIntegration) {
       const {
@@ -23,17 +29,20 @@ export async function onRespUpdate(component, props) {
         eventPoi,
       } = marketoIntegration;
 
-      const eventTypeSelect = component.querySelector('#marketo-event-type-select-input');
-      const salesforceCampaignIdInput = component.querySelector('#marketo-salesforce-campaign-id-input');
-      const mczProgramNameInput = component.querySelector('#marketo-mcz-program-name-input');
-      const coMarketingPartnerInput = component.querySelector('#marketo-co-marketing-partner-input');
-      const eventPoiInput = component.querySelector('#marketo-event-poi-input');
 
       if (eventType) eventTypeSelect.value = eventType;
       if (salesforceCampaignId) salesforceCampaignIdInput.value = salesforceCampaignId;
       if (mczProgramName) mczProgramNameInput.value = mczProgramName;
       if (coMarketingPartner) coMarketingPartnerInput.value = coMarketingPartner;
       if (eventPoi) eventPoiInput.value = eventPoi;
+    }
+
+    if (eventId) {
+      eventTypeSelect.disabled = true;
+      salesforceCampaignIdInput.disabled = true;
+      mczProgramNameInput.disabled = true;
+      coMarketingPartnerInput.disabled = true;
+      eventPoiInput.disabled = true;
     }
   }
 }

--- a/ecc/blocks/marketo-integration-component/controller.js
+++ b/ecc/blocks/marketo-integration-component/controller.js
@@ -102,6 +102,7 @@ export default async function init(component, props) {
         fieldsToDisable.forEach((field) => {
           const fieldInput = component.querySelector(`#${field.id}`);
           fieldInput.disabled = false;
+          if (fieldInput.required && fieldInput.value === '') fieldInput.invalid = true;
         });
       }
 

--- a/ecc/blocks/marketo-integration-component/controller.js
+++ b/ecc/blocks/marketo-integration-component/controller.js
@@ -29,7 +29,6 @@ export async function onRespUpdate(component, props) {
         eventPoi,
       } = marketoIntegration;
 
-
       if (eventType) eventTypeSelect.value = eventType;
       if (salesforceCampaignId) salesforceCampaignIdInput.value = salesforceCampaignId;
       if (mczProgramName) mczProgramNameInput.value = mczProgramName;

--- a/ecc/blocks/registration-fields-component/controller.js
+++ b/ecc/blocks/registration-fields-component/controller.js
@@ -56,6 +56,16 @@ function setBasicFormAttributes(rsvpForm, eventData, locale) {
   rsvpForm.required = requiredFields;
 }
 
+function filterRsvpConfigData(rsvpConfigData, eventData, props) {
+  let data = rsvpConfigData;
+  const marketoIntegration = getAttribute(eventData, 'marketoIntegration', props.locale);
+
+  if (marketoIntegration?.eventPoi) {
+    data = rsvpConfigData.filter(({ Field }) => Field !== 'primaryProductOfInterest');
+  }
+  return data;
+}
+
 async function setRsvpFormAttributes(props, eventData, component) {
   const rsvpFormConfigs = JSON.parse(component.dataset.rsvpFormConfigs);
   const cloudType = getAttribute(eventData, 'cloudType', props.locale);
@@ -69,7 +79,9 @@ async function setRsvpFormAttributes(props, eventData, component) {
   const rsvpForm = component.querySelector('div > rsvp-form');
   const rsvpConfig = rsvpFormConfigs.find(({ cloudType: cType }) => cType === cloudType);
 
-  rsvpForm.setAttribute('data', JSON.stringify(rsvpConfig?.config?.data));
+  const data = filterRsvpConfigData(rsvpConfig?.config?.data, eventData, props);
+
+  rsvpForm.setAttribute('data', JSON.stringify(data));
   rsvpForm.setAttribute('eventType', eventType);
 
   if ((eventType === EVENT_TYPES.WEBINAR && registration?.type === 'Marketo') || defaultForm === 'marketo') {

--- a/ecc/scripts/data-utils.js
+++ b/ecc/scripts/data-utils.js
@@ -42,7 +42,7 @@ export const MARKETO_INTEGRATION_DATA_REF_FILTER = {
   salesforceCampaignId: { type: 'string', submittable: true },
   mczProgramName: { type: 'string', submittable: true },
   coMarketingPartner: { type: 'string', submittable: true },
-  eventPoi: { type: 'string', submittable: true }
+  eventPoi: { type: 'string', submittable: true },
 };
 
 /**
@@ -96,7 +96,7 @@ export const EVENT_DATA_FILTER = {
   useLegacyDetailPagePath: { type: 'boolean', localizable: false, cloneable: false, submittable: true },
   video: { type: 'object', localizable: false, cloneable: true, submittable: true, ref: VIDEO_DATA_REF_FILTER },
   registration: { type: 'object', localizable: false, cloneable: true, submittable: true, ref: REGISTRATION_DATA_REF_FILTER },
-  marketoIntegration: { type: 'object', localizable: false, cloneable: true, submittable: true, ref: MARKETO_INTEGRATION_DATA_REF_FILTER },
+  marketoIntegration: { type: 'object', localizable: false, cloneable: false, submittable: true, ref: MARKETO_INTEGRATION_DATA_REF_FILTER },
 };
 
 /**


### PR DESCRIPTION
- Add a locking mechanism so that the marketo integration fields can't be interacted with after event creation
- Add a inter-block communication to disable primary product of interest selection in RSVP fields if event poi is selected
- Marketo Integration textfield validation fix https://jira.corp.adobe.com/browse/MWPW-174882
- Webinar clone fix

Test URLs:
- Before: https://dev--ecc-milo--adobecom.aem.live/drafts/
- After: https://marketo-int-fix--ecc-milo--adobecom.aem.live/drafts/

To test the feature, please load up the branch locally and run it against your local ESP and ESL server.
For more information on how to set up ESL and ESP locally, please refer to: [FE Dev Wiki](https://wiki.corp.adobe.com/display/adobedotcom/Events+Milo+FE+Dev+Wiki#EventsMiloFEDevWiki-Localdevelopmentsetup)
