### PR TITLE
Fixing speaker and sponsor 400/409 PUT calls

### DIFF
--- a/ecc/blocks/profile-component/controller.js
+++ b/ecc/blocks/profile-component/controller.js
@@ -1,12 +1,12 @@
 /* eslint-disable no-unused-vars */
-import { getAttribute, getSpeakerPayload } from '../../scripts/data-utils.js';
+import { getAttribute } from '../../scripts/data-utils.js';
 import {
   addSpeakerToEvent,
   getSpeakers,
   updateSpeakerInEvent,
   removeSpeakerFromEvent,
-  getEventSpeaker,
   getEvent,
+  getHydratedEventSpeaker,
 } from '../../scripts/esp-controller.js';
 
 export async function onSubmit(component, props) {
@@ -126,7 +126,7 @@ async function prefillProfiles(component, props) {
     const { eventId, seriesId } = d;
     try {
       // eslint-disable-next-line max-len
-      const speakers = await Promise.all(d.speakers.map(async (sp) => getEventSpeaker(seriesId, eventId, sp.speakerId)));
+      const speakers = await Promise.all(d.speakers.map(async (sp) => getHydratedEventSpeaker(seriesId, eventId, sp.speakerId)));
       for (let idx = 0; idx < d.speakers.length; idx += 1) {
         // eslint-disable-next-line max-len
         d.speakers[idx] = { ...d.speakers[idx], type: d.speakers[idx].speakerType, ...speakers[idx] };

--- a/ecc/scripts/constants.js
+++ b/ecc/scripts/constants.js
@@ -57,7 +57,7 @@ export const SUPPORTED_CLOUDS = [{ id: 'CreativeCloud', name: 'Creative Cloud' }
 
 export const API_CONFIG = {
   esl: {
-    [ENVIRONMENTS.LOCAL]: { host: 'http://localhost:8499' },
+    [ENVIRONMENTS.LOCAL]: { host: 'https://wcms-events-service-layer-deploy-ethos102-stage-va-9c3ecd.stage.cloud.adobe.io' },
     [ENVIRONMENTS.DEV]: { host: 'https://wcms-events-service-layer-deploy-ethos102-stage-va-9c3ecd.stage.cloud.adobe.io' },
     [ENVIRONMENTS.DEV02]: { host: 'https://wcms-events-service-layer-deploy-ethos102-stage-va-d5dc93.stage.cloud.adobe.io' },
     [ENVIRONMENTS.STAGE]: { host: 'https://events-service-layer-stage.adobe.io' },
@@ -65,7 +65,7 @@ export const API_CONFIG = {
     [ENVIRONMENTS.PROD]: { host: 'https://events-service-layer.adobe.io' },
   },
   esp: {
-    [ENVIRONMENTS.LOCAL]: { host: 'http://localhost:8500' },
+    [ENVIRONMENTS.LOCAL]: { host: 'https://wcms-events-service-platform-deploy-ethos102-stage-caff5f.stage.cloud.adobe.io' },
     [ENVIRONMENTS.DEV]: { host: 'https://wcms-events-service-platform-deploy-ethos102-stage-caff5f.stage.cloud.adobe.io' },
     [ENVIRONMENTS.DEV02]: { host: 'https://wcms-events-service-platform-deploy-ethos102-stage-c81eb6.stage.cloud.adobe.io' },
     [ENVIRONMENTS.STAGE]: { host: 'https://events-service-platform-stage-or2.adobe.io' },


### PR DESCRIPTION
This is a quick fix to allow an extra get call to get the events/speaker mod time (which is different from the series/speaker) and append that into the PUT calls to events/speaker call.

Same fix is applied for sponsors.

Resolves: [MWPW-175588](https://jira.corp.adobe.com/browse/MWPW-175588)

Test URLs:
- Before: https://dev--ecc-milo--adobecom.aem.live/drafts/
- After: https://event-speaker-put-fix--ecc-milo--adobecom.aem.live/drafts/

To test the feature, please load up the branch locally and run it against your local ESP and ESL server.
For more information on how to set up ESL and ESP locally, please refer to: [FE Dev Wiki](https://wiki.corp.adobe.com/display/adobedotcom/Events+Milo+FE+Dev+Wiki#EventsMiloFEDevWiki-Localdevelopmentsetup)
