### PR TITLE
Don't load default form if registration type is decided

### DIFF
--- a/ecc/blocks/registration-fields-component/controller.js
+++ b/ecc/blocks/registration-fields-component/controller.js
@@ -84,7 +84,9 @@ async function setRsvpFormAttributes(props, eventData, component) {
   rsvpForm.setAttribute('data', JSON.stringify(data));
   rsvpForm.setAttribute('eventType', eventType);
 
-  if ((eventType === EVENT_TYPES.WEBINAR && registration?.type === 'Marketo') || defaultForm === 'marketo') {
+  const eventHasMarketoForm = eventType === EVENT_TYPES.WEBINAR && registration?.type === 'Marketo';
+  const defaultFormIsMarketo = defaultForm === 'marketo' && !registration?.type;
+  if (eventHasMarketoForm || defaultFormIsMarketo) {
     setMarketoAttributes(rsvpForm, registration);
   } else {
     setBasicFormAttributes(rsvpForm, eventData, props.locale);


### PR DESCRIPTION
From John Fernandez:
(https://adobedotcom.slack.com/archives/C0932HMF666/p1750953984598139)
When I try to Save, it switches to the Marketo radio button option and requires me to input a Marketo Form URL.
I'm not sure why there's two different types of forms I can configure in Webinars but it always needs a Marketo Form URL.

Resolves: [MWPW-NUMBER](https://jira.corp.adobe.com/browse/MWPW-NUMBER)

Test URLs:
- Before: https://dev--ecc-milo--adobecom.aem.live/drafts/
- After: https://rsvp-comp-fix--ecc-milo--adobecom.aem.live/drafts/

To test the feature, please load up the branch locally and run it against your local ESP and ESL server.
For more information on how to set up ESL and ESP locally, please refer to: [FE Dev Wiki](https://wiki.corp.adobe.com/display/adobedotcom/Events+Milo+FE+Dev+Wiki#EventsMiloFEDevWiki-Localdevelopmentsetup)
