### PR TITLE
Remove RSVP fields duplicates

### DIFF
--- a/ecc/components/rsvp-form/rsvp-form.js
+++ b/ecc/components/rsvp-form/rsvp-form.js
@@ -66,10 +66,13 @@ export default class RsvpForm extends LitElement {
     const required = Array.from(this.required);
     const mandatedfields = this.data.filter((f) => f.Required === 'x').map((f) => f.Field);
 
+    const cleanVisible = Array.from(new Set([...mandatedfields, ...visible]));
+    const cleanRequired = Array.from(new Set([...mandatedfields, ...required]));
+
     return {
       rsvpFormFields: {
-        visible: [...mandatedfields, ...visible],
-        required: [...mandatedfields, ...required],
+        visible: cleanVisible,
+        required: cleanRequired,
       },
     };
   }


### PR DESCRIPTION
The RSVP fields attributes receives duplications due to array spreading. Using Set API to keep the visible and required array clean.

Resolves: https://jira.corp.adobe.com/browse/MWPW-176068

Test URLs:
- Before: https://<BASE_BRANCH>--ecc-milo--adobecom.aem.live/drafts/
- After: https://<TARGET_BRANCH>--ecc-milo--adobecom.aem.live/drafts/

To test the feature, please load up the branch locally and run it against your local ESP and ESL server.
For more information on how to set up ESL and ESP locally, please refer to: [FE Dev Wiki](https://wiki.corp.adobe.com/display/adobedotcom/Events+Milo+FE+Dev+Wiki#EventsMiloFEDevWiki-Localdevelopmentsetup)
