### PR TITLE
request for SP images rerouted from .page to .live

### DIFF
--- a/ecc/blocks/attendee-management-table/attendee-management-table.js
+++ b/ecc/blocks/attendee-management-table/attendee-management-table.js
@@ -374,7 +374,7 @@ async function buildEventInfo(props) {
     const firstImageObj = images?.[0];
 
     const imgSrc = (heroImgObj?.sharepointUrl
-      && `${getEventPageHost()}${heroImgObj?.sharepointUrl}`)
+      && `${getEventPageHost()}${heroImgObj?.sharepointUrl}`.replace('aem.page', 'aem.live'))
     || thumbnailImgObj?.imageUrl
     || heroImgObj?.imageUrl
     || firstImageObj?.imageUrl

--- a/ecc/blocks/ecc-dashboard/ecc-dashboard.js
+++ b/ecc/blocks/ecc-dashboard/ecc-dashboard.js
@@ -75,13 +75,19 @@ function buildThumbnail(data) {
 
     // TODO: Remember to remove the replace('https://www.adobe.com', '') once the images are returned with relative paths
     const imgSrc = (cardImage?.sharepointUrl
-      && `${getEventPageHost()}${cardImage?.sharepointUrl.replace('https://www.adobe.com', '')}`)
+      && `${getEventPageHost()}${cardImage?.sharepointUrl
+        .replace('https://www.adobe.com', '')
+      }`.replace('aem.page', 'aem.live'))
     || cardImage?.imageUrl
     || (heroImage?.sharepointUrl
-      && `${getEventPageHost()}${heroImage?.sharepointUrl.replace('https://www.adobe.com', '')}`)
+      && `${getEventPageHost()}${heroImage?.sharepointUrl
+        .replace('https://www.adobe.com', '')
+      }`.replace('aem.page', 'aem.live'))
     || heroImage?.imageUrl
     || (venueImage?.sharepointUrl
-      && `${getEventPageHost()}${venueImage?.sharepointUrl.replace('https://www.adobe.com', '')}`)
+      && `${getEventPageHost()}${venueImage?.sharepointUrl
+        .replace('https://www.adobe.com', '')
+      }`.replace('aem.page', 'aem.live'))
     || venueImage?.imageUrl
     || images[0]?.imageUrl;
 


### PR DESCRIPTION
Describe your specific features or fixes and provide a preview link for the feature being incorporated

Resolves: [MWPW-NUMBER](https://jira.corp.adobe.com/browse/MWPW-NUMBER)

Test URLs:
- Before: https://dev--ecc-milo--adobecom.aem.live/drafts/
- After: https://image-401-workaround--ecc-milo--adobecom.aem.live/drafts/

To test the feature, please load up the branch locally and run it against your local ESP and ESL server.
For more information on how to set up ESL and ESP locally, please refer to: [FE Dev Wiki](https://wiki.corp.adobe.com/display/adobedotcom/Events+Milo+FE+Dev+Wiki#EventsMiloFEDevWiki-Localdevelopmentsetup)
