### PR TITLE
Fixing required attribute to marketo integration pickers

### DIFF
--- a/ecc/blocks/marketo-integration-component/marketo-integration-component.js
+++ b/ecc/blocks/marketo-integration-component/marketo-integration-component.js
@@ -99,8 +99,8 @@ function decorateMarketoIntegrationFields(el, fields) {
       const fieldSelect = createTag('sp-picker', {
         id: field.id,
         size: 'l',
+        required: field.required,
       });
-      if (field.required) fieldSelect.required = true;
       if (!field.masterField) fieldSelect.disabled = true;
       const label = createTag('span', { slot: 'label' }, field.placeholder);
       fieldSelect.appendChild(label);


### PR DESCRIPTION
There was a small issue with the picker element not getting the required: true property set correctly. This should fix it.

Resolves: [MWPW-176362](https://jira.corp.adobe.com/browse/MWPW-176362)

Test URLs:
- Before: https://<BASE_BRANCH>--ecc-milo--adobecom.aem.live/drafts/
- After: https://<TARGET_BRANCH>--ecc-milo--adobecom.aem.live/drafts/

To test the feature, please load up the branch locally and run it against your local ESP and ESL server.
For more information on how to set up ESL and ESP locally, please refer to: [FE Dev Wiki](https://wiki.corp.adobe.com/display/adobedotcom/Events+Milo+FE+Dev+Wiki#EventsMiloFEDevWiki-Localdevelopmentsetup)
