### PR TITLE
adding temporary .hlx. replacement logic for legacy image URL support

### DIFF
--- a/ecc/blocks/attendee-management-table/attendee-management-table.js
+++ b/ecc/blocks/attendee-management-table/attendee-management-table.js
@@ -374,7 +374,8 @@ async function buildEventInfo(props) {
     const firstImageObj = images?.[0];
 
     const imgSrc = (heroImgObj?.sharepointUrl
-      && `${getEventPageHost()}${heroImgObj?.sharepointUrl}`.replace('aem.page', 'aem.live'))
+      && `${getEventPageHost()}${heroImgObj?.sharepointUrl}`.replace('.hlx.', '.aem.')
+        .replace('aem.page', 'aem.live'))
     || thumbnailImgObj?.imageUrl
     || heroImgObj?.imageUrl
     || firstImageObj?.imageUrl

--- a/ecc/blocks/ecc-dashboard/ecc-dashboard.js
+++ b/ecc/blocks/ecc-dashboard/ecc-dashboard.js
@@ -77,17 +77,20 @@ function buildThumbnail(data) {
     const imgSrc = (cardImage?.sharepointUrl
       && `${getEventPageHost()}${cardImage?.sharepointUrl
         .replace('https://www.adobe.com', '')
-      }`.replace('aem.page', 'aem.live'))
+      }`.replace('.hlx.', '.aem.')
+        .replace('aem.page', 'aem.live'))
     || cardImage?.imageUrl
     || (heroImage?.sharepointUrl
       && `${getEventPageHost()}${heroImage?.sharepointUrl
         .replace('https://www.adobe.com', '')
-      }`.replace('aem.page', 'aem.live'))
+      }`.replace('.hlx.', '.aem.')
+        .replace('aem.page', 'aem.live'))
     || heroImage?.imageUrl
     || (venueImage?.sharepointUrl
       && `${getEventPageHost()}${venueImage?.sharepointUrl
         .replace('https://www.adobe.com', '')
-      }`.replace('aem.page', 'aem.live'))
+      }`.replace('.hlx.', '.aem.')
+        .replace('aem.page', 'aem.live'))
     || venueImage?.imageUrl
     || images[0]?.imageUrl;
 


### PR DESCRIPTION
Test URLs:
- Before: https://dev--ecc-milo--adobecom.aem.live/drafts/
- After: https://hlx-replace--ecc-milo--adobecom.aem.live/drafts/

To test the feature, please load up the branch locally and run it against your local ESP and ESL server.
For more information on how to set up ESL and ESP locally, please refer to: [FE Dev Wiki](https://wiki.corp.adobe.com/display/adobedotcom/Events+Milo+FE+Dev+Wiki#EventsMiloFEDevWiki-Localdevelopmentsetup)
