### PR TITLE
fix a missed line for events-milo host swapping on localhost

### DIFF
--- a/ecc/scripts/environment.js
+++ b/ecc/scripts/environment.js
@@ -136,7 +136,7 @@ export function getEventServiceHost(relativeDomain, location = window.location) 
   }
 
   if (hostname.includes(DOMAINS.LOCALHOST)) {
-    return 'https://dev--events-milo--adobecom.hlx.page';
+    return 'https://dev--events-milo--adobecom.aem.page';
   }
 
   return `https://${DOMAINS.ADOBE_COM}`;

--- a/test/scripts/environment.test.js
+++ b/test/scripts/environment.test.js
@@ -107,7 +107,7 @@ describe('Environment Module', () => {
 
     it('should return correct host for localhost', () => {
       locationStub.hostname = DOMAINS.LOCALHOST;
-      expect(getEventServiceHost(undefined, locationStub)).to.equal('https://dev--events-milo--adobecom.hlx.page');
+      expect(getEventServiceHost(undefined, locationStub)).to.equal('https://dev--events-milo--adobecom.aem.page');
     });
 
     it('should return adobe.com as fallback', () => {


### PR DESCRIPTION
Test URLs:
- Before: https://dev--ecc-milo--adobecom.aem.live/drafts/
- After: https://fix-hlx-localhost--ecc-milo--adobecom.aem.live/drafts/

To test the feature, please load up the branch locally and run it against your local ESP and ESL server.
For more information on how to set up ESL and ESP locally, please refer to: [FE Dev Wiki](https://wiki.corp.adobe.com/display/adobedotcom/Events+Milo+FE+Dev+Wiki#EventsMiloFEDevWiki-Localdevelopmentsetup)
