### PR TITLE
Targets da-events instead of events-milo for DA migration

### DIFF
--- a/ecc/blocks/content-promotion-component/controller.js
+++ b/ecc/blocks/content-promotion-component/controller.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-unused-vars */
 import { getAttribute } from '../../scripts/data-utils.js';
-import { getEventPageHost } from '../../scripts/utils.js';
+import { getEventLibsHost } from '../../scripts/environment.js';
 import { setPropsPayload } from '../form-handler/data-handler.js';
 import { LOCALES } from '../../scripts/scripts.js';
 import { getLocales } from '../../scripts/esp-controller.js';
@@ -34,7 +34,8 @@ async function getPromotionalContentSheet(props) {
       return [];
     }
 
-    const sheetLocation = 'events/default/promotional-content.json';
+    // No longer pointing at Events Milo for promotional content.
+    const sheetLocation = 'event-libs/assets/configs/promotional-content.json';
     const locales = await getLocales().then((resp) => resp.localeNames) || {};
     const lName = locales[locale];
 
@@ -42,7 +43,7 @@ async function getPromotionalContentSheet(props) {
       .find(([, v]) => v.longName.toLowerCase() === lName?.toLowerCase()) || {};
     const localePrefix = targetLocaleObject[0];
 
-    const sheetResp = await fetch(`${getEventPageHost()}${localePrefix ? `/${localePrefix}` : ''}/${sheetLocation}`);
+    const sheetResp = await fetch(`${getEventLibsHost()}${localePrefix ? `/${localePrefix}` : ''}/${sheetLocation}`);
 
     if (!sheetResp.ok) {
       console.warn(`Failed to fetch promotional content: ${sheetResp.status} ${sheetResp.statusText}`);

--- a/ecc/blocks/content-promotion-component/controller.js
+++ b/ecc/blocks/content-promotion-component/controller.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-unused-vars */
 import { getAttribute } from '../../scripts/data-utils.js';
-import { getEventLibsHost } from '../../scripts/environment.js';
+import { getEventLibsHost } from '../../scripts/utils.js';
 import { setPropsPayload } from '../form-handler/data-handler.js';
 import { LOCALES } from '../../scripts/scripts.js';
 import { getLocales } from '../../scripts/esp-controller.js';

--- a/ecc/blocks/form-handler/form-handler-helper.js
+++ b/ecc/blocks/form-handler/form-handler-helper.js
@@ -28,7 +28,7 @@ import {
   buildNoAccessScreen,
   generateToolTip,
   camelToSentenceCase,
-  getEventPageHost,
+  getEventLibsHost,
   replaceAnchorWithButton,
   getMetadata,
   isPublishingLocked,
@@ -734,7 +734,7 @@ async function getNonProdPreviewDataById(props) {
     .find(([, v]) => v.longName.toLowerCase() === lName?.toLowerCase()) || {};
   const localePrefix = targetLocaleObject[0];
 
-  const resp = await fetch(`${getEventPageHost()}${localePrefix ? `/${localePrefix}` : ''}/events/default/${esEnv === ENVIRONMENTS.PROD ? '' : `${esEnv}/`}metadata-preview.json?limit=999999`);
+  const resp = await fetch(`${getEventLibsHost()}${localePrefix ? `/${localePrefix}` : ''}/events/default/${esEnv === ENVIRONMENTS.PROD ? '' : `${esEnv}/`}metadata-preview.json?limit=999999`);
   if (resp.ok) {
     const json = await resp.json();
     const pageData = json.data.reverse().find((d) => d['event-id'] === eventId);

--- a/ecc/scripts/environment.js
+++ b/ecc/scripts/environment.js
@@ -166,7 +166,7 @@ export function getEventServiceHost(relativeDomain, location = window.location) 
  * @returns {string} The event service host URL
  * @throws {Error} If environment detection is not available
  */
-export function getEventLibsHost(relativeDomain, location = window.location) {
+export function getDAHost(relativeDomain, location = window.location) {
   const currentEnv = getCurrentEnvironment(location);
   const { hostname, href, origin } = location;
 

--- a/ecc/scripts/environment.js
+++ b/ecc/scripts/environment.js
@@ -108,6 +108,23 @@ export function getImsEnvironment(location = window.location) {
   return currentEnv === ENVIRONMENTS.PROD ? IMS_ENVIRONMENTS.PROD : IMS_ENVIRONMENTS.STAGE;
 }
 
+export function getContentTarget() {
+  const currentOrigin = window.location.origin;
+
+  const isDotPage = currentOrigin.endsWith('.page');
+  const isDotLive = currentOrigin.endsWith('.live');
+
+  if (isDotPage) {
+    return 'page';
+  }
+
+  if (isDotLive) {
+    return 'live';
+  }
+
+  return 'live';
+}
+
 /**
  * Gets the event service host based on the current environment
  * @param {string} [relativeDomain] - Optional relative domain to use
@@ -122,7 +139,7 @@ export function getEventServiceHost(relativeDomain, location = window.location) 
   if (href.includes('.hlx.') || href.includes('.aem.')) {
     return origin.replace(
       hostname,
-      `${currentEnv}--events-milo--adobecom.aem.page`,
+      `${currentEnv}--da-events--adobecom.${getContentTarget()}`,
     );
   }
 
@@ -137,6 +154,40 @@ export function getEventServiceHost(relativeDomain, location = window.location) 
 
   if (hostname.includes(DOMAINS.LOCALHOST)) {
     return 'https://dev--events-milo--adobecom.aem.page';
+  }
+
+  return `https://${DOMAINS.ADOBE_COM}`;
+}
+
+/**
+ * Gets the event service host based on the current environment
+ * @param {string} [relativeDomain] - Optional relative domain to use
+ * @param {Location} [location=window.location]
+ * @returns {string} The event service host URL
+ * @throws {Error} If environment detection is not available
+ */
+export function getEventLibsHost(relativeDomain, location = window.location) {
+  const currentEnv = getCurrentEnvironment(location);
+  const { hostname, href, origin } = location;
+
+  if (href.includes('.hlx.') || href.includes('.aem.')) {
+    return origin.replace(
+      hostname,
+      `${currentEnv}--event-libs--adobecom.aem.live`,
+    );
+  }
+
+  if (relativeDomain) return relativeDomain;
+
+  if ([
+    DOMAINS.STAGE_ADOBE_COM,
+    DOMAINS.ADOBE_COM,
+  ].includes(hostname)) {
+    return origin;
+  }
+
+  if (hostname.includes(DOMAINS.LOCALHOST)) {
+    return 'https://dev--event-libs--adobecom.aem.live';
   }
 
   return `https://${DOMAINS.ADOBE_COM}`;

--- a/ecc/scripts/utils.js
+++ b/ecc/scripts/utils.js
@@ -107,6 +107,10 @@ export function parse24HourFormat(timeStr) {
   };
 }
 
+export function getEventLibsHost(relativeDomain) {
+  return getEventLibsHost(relativeDomain);
+}
+
 export function getEventPageHost(relativeDomain) {
   return getEventServiceHost(relativeDomain);
 }

--- a/ecc/scripts/utils.js
+++ b/ecc/scripts/utils.js
@@ -1,5 +1,5 @@
 import { LIBS, CONFIG } from './scripts.js';
-import { getEventServiceHost } from './environment.js';
+import { getEventServiceHost, getDAHost } from './environment.js';
 
 export function createTag(tag, attributes, html, options = {}) {
   const el = document.createElement(tag);
@@ -108,7 +108,7 @@ export function parse24HourFormat(timeStr) {
 }
 
 export function getEventLibsHost(relativeDomain) {
-  return getEventLibsHost(relativeDomain);
+  return getDAHost(relativeDomain);
 }
 
 export function getEventPageHost(relativeDomain) {

--- a/test/scripts/environment.test.js
+++ b/test/scripts/environment.test.js
@@ -91,7 +91,7 @@ describe('Environment Module', () => {
       locationStub.host = 'dev--events-milo--adobecom.aem.page';
       locationStub.hostname = 'dev--events-milo--adobecom.aem.page';
       locationStub.origin = 'https://dev--events-milo--adobecom.aem.page';
-      expect(getEventServiceHost(undefined, locationStub)).to.equal('https://dev--events-milo--adobecom.aem.page');
+      expect(getEventServiceHost(undefined, locationStub)).to.equal('https://dev--da-events--adobecom.live');
     });
 
     it('should return relativeDomain if provided', () => {


### PR DESCRIPTION
Test URLs:
- Before: https://dev--ecc-milo--adobecom.aem.live/drafts/
- After: https://va-target-da-events--ecc-milo--adobecom.aem.live/drafts/

To test the feature, please load up the branch locally and run it against your local ESP and ESL server.
For more information on how to set up ESL and ESP locally, please refer to: [FE Dev Wiki](https://wiki.corp.adobe.com/display/adobedotcom/Events+Milo+FE+Dev+Wiki#EventsMiloFEDevWiki-Localdevelopmentsetup)
