### PR TITLE
Add stage/prod domain prediction for preview navigation

### DIFF
--- a/ecc/blocks/ecc-dashboard/ecc-dashboard.js
+++ b/ecc/blocks/ecc-dashboard/ecc-dashboard.js
@@ -25,7 +25,9 @@ import {
 import { initProfileLogicTree } from '../../scripts/profile.js';
 import { cloneFilter, eventObjFilter } from './dashboard-utils.js';
 import { getAttribute, setEventAttribute } from '../../scripts/data-utils.js';
-import { EVENT_TYPES } from '../../scripts/constants.js';
+import { EVENT_TYPES, ENVIRONMENTS } from '../../scripts/constants.js';
+import { getCurrentEnvironment } from '../../scripts/environment.js';
+import { toStageOrigin } from '../../scripts/domain-mapping.js';
 
 // API Cache and Throttling System (functional approach)
 const apiCache = (() => {
@@ -425,14 +427,23 @@ function initMoreOptions(props, config, eventObj, row) {
     const deleteBtn = buildTool(toolBox, 'Delete', 'delete-wire-round');
 
     if (eventObj.detailPagePath) {
-      previewPre.href = (() => {
+      const resolvePreviewUrl = (detailPagePath) => {
         let url;
-
         try {
-          url = new URL(`${eventObj.detailPagePath}`);
+          url = new URL(detailPagePath);
         } catch (e) {
-          url = new URL(`${getEventPageHost()}${eventObj.detailPagePath}`);
+          url = new URL(`${getEventPageHost()}${detailPagePath}`);
         }
+
+        if (getCurrentEnvironment() !== ENVIRONMENTS.PROD) {
+          url = new URL(toStageOrigin(url.href));
+        }
+
+        return url;
+      };
+
+      previewPre.href = (() => {
+        const url = resolvePreviewUrl(eventObj.detailPagePath);
 
         if (url) {
           url.searchParams.set('previewMode', 'true');
@@ -445,12 +456,7 @@ function initMoreOptions(props, config, eventObj, row) {
       previewPre.target = '_blank';
 
       previewPost.href = (() => {
-        let url;
-        try {
-          url = new URL(`${eventObj.detailPagePath}`);
-        } catch (e) {
-          url = new URL(`${getEventPageHost()}${eventObj.detailPagePath}`);
-        }
+        const url = resolvePreviewUrl(eventObj.detailPagePath);
 
         if (url) {
           url.searchParams.set('previewMode', 'true');

--- a/ecc/blocks/form-handler/form-handler-helper.js
+++ b/ecc/blocks/form-handler/form-handler-helper.js
@@ -28,6 +28,7 @@ import {
   buildNoAccessScreen,
   generateToolTip,
   camelToSentenceCase,
+  getEventPageHost,
   getEventLibsHost,
   replaceAnchorWithButton,
   getMetadata,
@@ -47,6 +48,7 @@ import {
 } from '../../scripts/esp-controller.js';
 import { getAttribute } from '../../scripts/data-utils.js';
 import { ENVIRONMENTS, EVENT_TYPES, DEFAULT_SAVE_POLICIES } from '../../scripts/constants.js';
+import { toStageOrigin } from '../../scripts/domain-mapping.js';
 
 const { createTag } = await import(`${LIBS}/utils/utils.js`);
 const { decorateButtons } = await import(`${LIBS}/utils/decorate.js`);
@@ -1011,6 +1013,10 @@ function updateCtas(props) {
           previewUrl = new URL(eventDataResp.detailPagePath).href;
         } catch (e) {
           previewUrl = `${getEventPageHost()}${eventDataResp.detailPagePath}`;
+        }
+
+        if (getCurrentEnvironment() !== ENVIRONMENTS.PROD) {
+          previewUrl = toStageOrigin(previewUrl);
         }
 
         a.href = `${previewUrl}?previewMode=true&cachebuster=${Date.now()}&timing=${testTime}`;

--- a/ecc/scripts/domain-mapping.js
+++ b/ecc/scripts/domain-mapping.js
@@ -1,0 +1,119 @@
+/**
+ * Stage/Prod domain prediction module.
+ *
+ * Provides bidirectional origin mapping between stage and production environments.
+ * Used for event preview page navigation to ensure URLs point to the correct
+ * environment across the dashboard and event creation form.
+ *
+ * @module domain-mapping
+ */
+
+/**
+ * Domain mapping pairs between stage and production.
+ *
+ * To add a new mapping, add an entry to this array:
+ * - Exact hostnames: { prod: 'example.com', stage: 'stage.example.com' }
+ * - Suffix patterns (values starting with '.'):
+ *   { prod: '.cdn.com', stage: '.cdn-stage.com' }
+ *
+ * Entries are matched top-to-bottom. First match wins.
+ */
+export const DOMAIN_MAP = [
+  { prod: 'www.adobe.com', stage: 'www.stage.adobe.com' },
+  { prod: 'business.adobe.com', stage: 'business.stage.adobe.com' },
+  { prod: '.aem.live', stage: '.aem.page' },
+];
+
+function isSuffixEntry(value) {
+  return value.startsWith('.');
+}
+
+/**
+ * Finds a matching map entry and returns the mapped hostname.
+ * @param {string} hostname - The hostname to look up
+ * @param {'prod'|'stage'} fromKey - The source direction
+ * @param {'prod'|'stage'} toKey - The target direction
+ * @returns {string|null} The mapped hostname, or null if no match
+ */
+function mapHostname(hostname, fromKey, toKey) {
+  for (const entry of DOMAIN_MAP) {
+    const from = entry[fromKey];
+    const to = entry[toKey];
+
+    if (isSuffixEntry(from)) {
+      if (hostname.endsWith(from)) {
+        return hostname.slice(0, -from.length) + to;
+      }
+    } else if (hostname === from) {
+      return to;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Transforms a URL, origin, or hostname between environments.
+ * Returns the input unchanged if no mapping matches.
+ * @param {string} input - A full URL, origin, or bare hostname
+ * @param {'prod'|'stage'} fromKey - The source direction
+ * @param {'prod'|'stage'} toKey - The target direction
+ * @returns {string} The transformed input
+ */
+function transformUrl(input, fromKey, toKey) {
+  if (!input) return input;
+
+  try {
+    const url = new URL(input);
+    const mapped = mapHostname(url.hostname, fromKey, toKey);
+    if (!mapped) return input;
+    return input.replace(url.hostname, mapped);
+  } catch {
+    const mapped = mapHostname(input, fromKey, toKey);
+    return mapped || input;
+  }
+}
+
+/**
+ * Transforms a URL, origin, or hostname to its stage equivalent.
+ * If the input is already a stage origin or doesn't match any mapping,
+ * it is returned unchanged.
+ *
+ * @param {string} input - A full URL, origin, or bare hostname
+ * @returns {string} The stage-equivalent input
+ *
+ * @example
+ * toStageOrigin('https://www.adobe.com')
+ * // => 'https://www.stage.adobe.com'
+ *
+ * toStageOrigin('https://main--site--org.aem.live/events/my-event')
+ * // => 'https://main--site--org.aem.page/events/my-event'
+ *
+ * toStageOrigin('www.adobe.com')
+ * // => 'www.stage.adobe.com'
+ */
+export function toStageOrigin(input) {
+  return transformUrl(input, 'prod', 'stage');
+}
+
+/**
+ * Transforms a URL, origin, or hostname to its production equivalent.
+ * If the input is already a production origin or doesn't match any mapping,
+ * it is returned unchanged.
+ *
+ * @param {string} input - A full URL, origin, or bare hostname
+ * @returns {string} The production-equivalent input
+ *
+ * @example
+ * toProdOrigin('https://www.stage.adobe.com')
+ * // => 'https://www.adobe.com'
+ *
+ * toProdOrigin('https://main--site--org.aem.page/events/my-event')
+ * // => 'https://main--site--org.aem.live/events/my-event'
+ *
+ * toProdOrigin('www.stage.adobe.com')
+ * // => 'www.adobe.com'
+ */
+export function toProdOrigin(input) {
+  return transformUrl(input, 'stage', 'prod');
+}

--- a/test/scripts/domain-mapping.test.js
+++ b/test/scripts/domain-mapping.test.js
@@ -1,0 +1,177 @@
+import { expect } from '@esm-bundle/chai';
+import { DOMAIN_MAP, toStageOrigin, toProdOrigin } from '../../ecc/scripts/domain-mapping.js';
+
+describe('Domain Mapping Module', () => {
+  describe('DOMAIN_MAP', () => {
+    it('should be a non-empty array', () => {
+      expect(DOMAIN_MAP).to.be.an('array').that.is.not.empty;
+    });
+
+    it('should have prod and stage keys for every entry', () => {
+      DOMAIN_MAP.forEach((entry) => {
+        expect(entry).to.have.property('prod').that.is.a('string');
+        expect(entry).to.have.property('stage').that.is.a('string');
+      });
+    });
+  });
+
+  describe('toStageOrigin', () => {
+    it('should map www.adobe.com to www.stage.adobe.com', () => {
+      expect(toStageOrigin('https://www.adobe.com')).to.equal('https://www.stage.adobe.com');
+    });
+
+    it('should map www.adobe.com with a path', () => {
+      expect(toStageOrigin('https://www.adobe.com/events/my-event'))
+        .to.equal('https://www.stage.adobe.com/events/my-event');
+    });
+
+    it('should map business.adobe.com to business.stage.adobe.com', () => {
+      expect(toStageOrigin('https://business.adobe.com'))
+        .to.equal('https://business.stage.adobe.com');
+    });
+
+    it('should map business.adobe.com with a path', () => {
+      expect(toStageOrigin('https://business.adobe.com/events/summit'))
+        .to.equal('https://business.stage.adobe.com/events/summit');
+    });
+
+    it('should map .aem.live suffix to .aem.page', () => {
+      expect(toStageOrigin('https://main--da-events--adobecom.aem.live'))
+        .to.equal('https://main--da-events--adobecom.aem.page');
+    });
+
+    it('should map .aem.live with a path', () => {
+      expect(toStageOrigin('https://main--da-events--adobecom.aem.live/events/my-event'))
+        .to.equal('https://main--da-events--adobecom.aem.page/events/my-event');
+    });
+
+    it('should handle various AEM host prefixes', () => {
+      expect(toStageOrigin('https://stage--da-events--adobecom.aem.live'))
+        .to.equal('https://stage--da-events--adobecom.aem.page');
+      expect(toStageOrigin('https://dev--event-libs--adobecom.aem.live'))
+        .to.equal('https://dev--event-libs--adobecom.aem.page');
+    });
+
+    it('should return input unchanged for already-stage origins', () => {
+      expect(toStageOrigin('https://www.stage.adobe.com')).to.equal('https://www.stage.adobe.com');
+      expect(toStageOrigin('https://main--da-events--adobecom.aem.page'))
+        .to.equal('https://main--da-events--adobecom.aem.page');
+    });
+
+    it('should return input unchanged for unknown domains', () => {
+      expect(toStageOrigin('https://example.com')).to.equal('https://example.com');
+      expect(toStageOrigin('https://unknown.domain.org/path')).to.equal('https://unknown.domain.org/path');
+    });
+
+    it('should handle bare hostnames', () => {
+      expect(toStageOrigin('www.adobe.com')).to.equal('www.stage.adobe.com');
+      expect(toStageOrigin('business.adobe.com')).to.equal('business.stage.adobe.com');
+    });
+
+    it('should preserve query parameters and fragments', () => {
+      expect(toStageOrigin('https://www.adobe.com/events?id=123#section'))
+        .to.equal('https://www.stage.adobe.com/events?id=123#section');
+    });
+
+    it('should handle null and empty inputs', () => {
+      expect(toStageOrigin(null)).to.equal(null);
+      expect(toStageOrigin(undefined)).to.equal(undefined);
+      expect(toStageOrigin('')).to.equal('');
+    });
+  });
+
+  describe('toProdOrigin', () => {
+    it('should map www.stage.adobe.com to www.adobe.com', () => {
+      expect(toProdOrigin('https://www.stage.adobe.com')).to.equal('https://www.adobe.com');
+    });
+
+    it('should map www.stage.adobe.com with a path', () => {
+      expect(toProdOrigin('https://www.stage.adobe.com/events/my-event'))
+        .to.equal('https://www.adobe.com/events/my-event');
+    });
+
+    it('should map business.stage.adobe.com to business.adobe.com', () => {
+      expect(toProdOrigin('https://business.stage.adobe.com'))
+        .to.equal('https://business.adobe.com');
+    });
+
+    it('should map .aem.page suffix to .aem.live', () => {
+      expect(toProdOrigin('https://main--da-events--adobecom.aem.page'))
+        .to.equal('https://main--da-events--adobecom.aem.live');
+    });
+
+    it('should map .aem.page with a path', () => {
+      expect(toProdOrigin('https://main--da-events--adobecom.aem.page/events/my-event'))
+        .to.equal('https://main--da-events--adobecom.aem.live/events/my-event');
+    });
+
+    it('should handle various AEM host prefixes', () => {
+      expect(toProdOrigin('https://stage--da-events--adobecom.aem.page'))
+        .to.equal('https://stage--da-events--adobecom.aem.live');
+      expect(toProdOrigin('https://dev--event-libs--adobecom.aem.page'))
+        .to.equal('https://dev--event-libs--adobecom.aem.live');
+    });
+
+    it('should return input unchanged for already-prod origins', () => {
+      expect(toProdOrigin('https://www.adobe.com')).to.equal('https://www.adobe.com');
+      expect(toProdOrigin('https://main--da-events--adobecom.aem.live'))
+        .to.equal('https://main--da-events--adobecom.aem.live');
+    });
+
+    it('should return input unchanged for unknown domains', () => {
+      expect(toProdOrigin('https://example.com')).to.equal('https://example.com');
+    });
+
+    it('should handle bare hostnames', () => {
+      expect(toProdOrigin('www.stage.adobe.com')).to.equal('www.adobe.com');
+      expect(toProdOrigin('business.stage.adobe.com')).to.equal('business.adobe.com');
+    });
+
+    it('should preserve query parameters and fragments', () => {
+      expect(toProdOrigin('https://www.stage.adobe.com/events?id=123#section'))
+        .to.equal('https://www.adobe.com/events?id=123#section');
+    });
+
+    it('should handle null and empty inputs', () => {
+      expect(toProdOrigin(null)).to.equal(null);
+      expect(toProdOrigin(undefined)).to.equal(undefined);
+      expect(toProdOrigin('')).to.equal('');
+    });
+  });
+
+  describe('round-trip consistency', () => {
+    it('should be idempotent for stage origins', () => {
+      const stageUrl = 'https://www.stage.adobe.com/events/page';
+      expect(toStageOrigin(stageUrl)).to.equal(stageUrl);
+    });
+
+    it('should be idempotent for prod origins', () => {
+      const prodUrl = 'https://www.adobe.com/events/page';
+      expect(toProdOrigin(prodUrl)).to.equal(prodUrl);
+    });
+
+    it('should round-trip prod -> stage -> prod', () => {
+      const prodUrl = 'https://www.adobe.com/events/my-event';
+      const stageUrl = toStageOrigin(prodUrl);
+      expect(toProdOrigin(stageUrl)).to.equal(prodUrl);
+    });
+
+    it('should round-trip stage -> prod -> stage', () => {
+      const stageUrl = 'https://www.stage.adobe.com/events/my-event';
+      const prodUrl = toProdOrigin(stageUrl);
+      expect(toStageOrigin(prodUrl)).to.equal(stageUrl);
+    });
+
+    it('should round-trip .aem.live -> .aem.page -> .aem.live', () => {
+      const liveUrl = 'https://main--da-events--adobecom.aem.live/events/page';
+      const pageUrl = toStageOrigin(liveUrl);
+      expect(toProdOrigin(pageUrl)).to.equal(liveUrl);
+    });
+
+    it('should round-trip .aem.page -> .aem.live -> .aem.page', () => {
+      const pageUrl = 'https://main--da-events--adobecom.aem.page/events/page';
+      const liveUrl = toProdOrigin(pageUrl);
+      expect(toStageOrigin(liveUrl)).to.equal(pageUrl);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Introduces `ecc/scripts/domain-mapping.js` — a plug-and-play module with an easy-to-maintain map for bidirectional stage/prod origin prediction
- Integrates domain mapping into event preview URL construction in both the **event dashboard** and **event creation form**, so preview links resolve to the correct environment (e.g. `www.adobe.com` → `www.stage.adobe.com` on non-prod, `.aem.live` ↔ `.aem.page`)
- Fixes a missing `getEventPageHost` import in `form-handler-helper.js`

## Test plan
- [ ] Verify `npm test` passes (31 new domain-mapping tests + existing suite)
- [ ] On a stage environment, confirm "Preview pre-event" / "Preview post-event" links in the **dashboard** point to stage origins (e.g. `www.stage.adobe.com`, `.aem.page`)
- [ ] On a stage environment, confirm preview buttons in the **event creation form** point to stage origins
- [ ] On prod, confirm preview links remain unchanged (no transformation applied)
- [ ] Verify adding a new entry to `DOMAIN_MAP` (exact or suffix) works as expected


Made with [Cursor](https://cursor.com)