### PR TITLE
T3-26.10 Stage Release

### DIFF
--- a/ecc/blocks/campaign-management-table/campaign-management-table.css
+++ b/ecc/blocks/campaign-management-table/campaign-management-table.css
@@ -189,7 +189,7 @@
   width: 100%;
 }
 
-.campaign-management-table .capacity-input {
+.campaign-management-table .field-row .capacity-input {
   box-sizing: border-box;
   padding: 8px 12px;
   font-size: var(--type-body-s-size);

--- a/ecc/blocks/campaign-management-table/campaign-management-table.css
+++ b/ecc/blocks/campaign-management-table/campaign-management-table.css
@@ -1,7 +1,8 @@
 .campaign-management-table {
   font-family: var(--body-font-family);
   max-width: 1440px;
-  padding: 0 40px 40px;
+  min-height: 100vh;
+  padding: 40px;
   margin: auto;
 }
 

--- a/ecc/blocks/campaign-management-table/campaign-management-table.css
+++ b/ecc/blocks/campaign-management-table/campaign-management-table.css
@@ -183,8 +183,29 @@
   gap: 4px;
 }
 
-.campaign-management-table .field-row sp-textfield {
+.campaign-management-table .field-row sp-textfield,
+.campaign-management-table .field-row .capacity-input {
   width: 100%;
+}
+
+.campaign-management-table .capacity-input {
+  box-sizing: border-box;
+  padding: 8px 12px;
+  font-size: var(--type-body-s-size);
+  font-family: var(--body-font-family);
+  border: 1px solid var(--color-gray-400);
+  border-radius: 4px;
+  outline: none;
+}
+
+.campaign-management-table .capacity-input:focus {
+  border-color: var(--color-accent);
+}
+
+.campaign-management-table .capacity-input:disabled {
+  background: var(--color-gray-100);
+  color: var(--color-gray-500);
+  cursor: not-allowed;
 }
 
 .campaign-management-table .field-row .helper-text {

--- a/ecc/blocks/campaign-management-table/campaign-management-table.css
+++ b/ecc/blocks/campaign-management-table/campaign-management-table.css
@@ -1,0 +1,243 @@
+.campaign-management-table {
+  font-family: var(--body-font-family);
+  max-width: 1440px;
+  padding: 0 40px 40px;
+  margin: auto;
+}
+
+/* Loading */
+
+.campaign-management-table .loading-screen {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 300px;
+}
+
+/* Stats row */
+
+.campaign-management-table .campaign-stats {
+  display: flex;
+  gap: 40px;
+  padding: 24px;
+  background: var(--color-gray-100);
+  border-radius: 8px;
+  margin-bottom: 24px;
+}
+
+.campaign-management-table .stat {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.campaign-management-table .stat-label {
+  font-size: var(--type-body-xxs-size);
+  font-weight: 700;
+  color: var(--color-gray-500);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.campaign-management-table .stat-value {
+  font-size: var(--type-heading-l-size);
+  font-weight: 700;
+  color: var(--color-black);
+}
+
+.campaign-management-table .stat-subtext {
+  font-size: var(--type-body-xxs-size);
+  font-weight: 400;
+  color: var(--color-gray-500);
+  margin-left: 4px;
+}
+
+/* Actions bar */
+
+.campaign-management-table .campaign-actions-bar {
+  margin-bottom: 16px;
+}
+
+/* Table */
+
+.campaign-management-table .campaign-table-wrapper {
+  overflow-x: auto;
+}
+
+.campaign-management-table .campaign-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.campaign-management-table .campaign-table thead th {
+  text-align: left;
+  font-size: var(--type-body-xxs-size);
+  font-weight: 700;
+  color: var(--color-gray-500);
+  text-transform: uppercase;
+  padding: 12px 16px;
+  border-bottom: 2px solid var(--color-gray-300);
+  white-space: nowrap;
+}
+
+.campaign-management-table .campaign-table tbody tr {
+  border-bottom: 1px solid var(--color-gray-200);
+}
+
+.campaign-management-table .campaign-table tbody tr:hover {
+  background: var(--color-gray-100);
+}
+
+.campaign-management-table .campaign-table td {
+  padding: 12px 16px;
+  font-size: var(--type-body-s-size);
+  vertical-align: middle;
+}
+
+.campaign-management-table .campaign-name-cell {
+  font-weight: 600;
+}
+
+.campaign-management-table .url-param-cell {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.campaign-management-table .url-param-text {
+  font-family: monospace;
+  font-size: var(--type-body-xs-size);
+  color: var(--color-gray-700);
+}
+
+.campaign-management-table .actions-col {
+  text-align: right;
+  white-space: nowrap;
+}
+
+/* Status badges */
+
+.campaign-management-table .status-badge {
+  display: inline-block;
+  padding: 2px 12px;
+  border-radius: 12px;
+  font-size: var(--type-body-xxs-size);
+  font-weight: 600;
+}
+
+.campaign-management-table .status-badge.active {
+  background: #e6f4ea;
+  color: #1e7e34;
+}
+
+.campaign-management-table .status-badge.archived {
+  background: var(--color-gray-200);
+  color: var(--color-gray-600);
+}
+
+/* Empty state */
+
+.campaign-management-table .empty-state {
+  text-align: center;
+  padding: 48px 16px;
+  color: var(--color-gray-500);
+}
+
+/* Dialogs */
+
+.campaign-management-table .campaign-dialog {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 2;
+  background: var(--color-white);
+  border-radius: 8px;
+  padding: 24px 32px;
+  min-width: 480px;
+  max-width: 560px;
+  box-shadow: 0 8px 24px rgb(0 0 0 / 20%);
+}
+
+.campaign-management-table .campaign-dialog h2 {
+  font-size: var(--type-heading-s-size);
+  margin: 0 0 8px;
+}
+
+.campaign-management-table .dialog-body {
+  margin: 16px 0 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.campaign-management-table .dialog-body p {
+  font-size: var(--type-body-s-size);
+  line-height: 1.5;
+  margin: 0;
+}
+
+.campaign-management-table .field-row {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.campaign-management-table .field-row sp-textfield {
+  width: 100%;
+}
+
+.campaign-management-table .field-row .helper-text {
+  font-size: var(--type-body-xxs-size);
+  color: var(--color-gray-500);
+}
+
+.campaign-management-table .switch-row {
+  flex-direction: row;
+  align-items: center;
+  gap: 8px;
+}
+
+.campaign-management-table .tracking-link-row {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 8px 12px;
+  background: var(--color-gray-100);
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.campaign-management-table .tracking-link-text {
+  flex: 1;
+  font-size: var(--type-body-xs-size);
+  color: var(--color-gray-700);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.campaign-management-table .dialog-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+}
+
+/* Toast */
+
+.campaign-management-table .toast-area {
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  z-index: 10;
+}
+
+/* No access */
+
+.campaign-management-table.no-access {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 400px;
+}

--- a/ecc/blocks/campaign-management-table/campaign-management-table.js
+++ b/ecc/blocks/campaign-management-table/campaign-management-table.js
@@ -5,7 +5,7 @@ import {
   updateCampaign,
   deleteCampaign,
 } from '../../scripts/esp-controller.js';
-import { getIcon, buildNoAccessScreen, signIn } from '../../scripts/utils.js';
+import { buildNoAccessScreen, signIn } from '../../scripts/utils.js';
 import { initProfileLogicTree } from '../../scripts/profile.js';
 
 const { LitElement, html, repeat, nothing } = await import(`${LIBS}/deps/lit-all.min.js`);
@@ -145,7 +145,7 @@ class CampaignTable extends LitElement {
     }
   }
 
-  extractUrlParam(campaign) {
+  static extractUrlParam(campaign) {
     if (!campaign.url) return '';
     try {
       const url = new URL(campaign.url);
@@ -290,7 +290,7 @@ class CampaignTable extends LitElement {
               <tr>
                 <td class="campaign-name-cell">${c.name}</td>
                 <td class="url-param-cell">
-                  <span class="url-param-text">${this.extractUrlParam(c)}</span>
+                  <span class="url-param-text">${CampaignTable.extractUrlParam(c)}</span>
                   <sp-action-button size="xl" quiet label="Copy URL"
                     @click=${() => this.copyToClipboard(c.url || '')}>
                     <img src="/ecc/icons/copy.svg" slot="icon" alt="copy">

--- a/ecc/blocks/campaign-management-table/campaign-management-table.js
+++ b/ecc/blocks/campaign-management-table/campaign-management-table.js
@@ -27,6 +27,42 @@ const SPECTRUM_COMPONENTS = [
   'divider',
 ];
 
+const MOCK_CAMPAIGNS = [
+  {
+    campaignId: 'mock-1',
+    name: 'Partner Promotion',
+    status: 'Active',
+    attendeeLimit: 50,
+    attendeeCount: 23,
+    waitlistAttendeeCount: 0,
+    url: 'https://www.adobe.com/events/example?campaign=partner-promo',
+    creationTime: Date.now(),
+    modificationTime: Date.now(),
+  },
+  {
+    campaignId: 'mock-2',
+    name: 'Email Newsletter',
+    status: 'Active',
+    attendeeLimit: 100,
+    attendeeCount: 67,
+    waitlistAttendeeCount: 0,
+    url: 'https://www.adobe.com/events/example?campaign=email-newsletter',
+    creationTime: Date.now(),
+    modificationTime: Date.now(),
+  },
+  {
+    campaignId: 'mock-3',
+    name: 'Social Media',
+    status: 'Archived',
+    attendeeLimit: 0,
+    attendeeCount: 45,
+    waitlistAttendeeCount: 0,
+    url: 'https://www.adobe.com/events/example?campaign=social',
+    creationTime: Date.now(),
+    modificationTime: Date.now(),
+  },
+];
+
 class CampaignTable extends LitElement {
   static properties = {
     eventId: { type: String },
@@ -68,10 +104,12 @@ class CampaignTable extends LitElement {
       if (Array.isArray(resp)) {
         this.campaigns = resp;
       } else {
-        this.campaigns = [];
+        window.lana?.log('Campaign fetch did not return an array, using mock data');
+        this.campaigns = MOCK_CAMPAIGNS;
       }
     } catch {
-      this.campaigns = [];
+      window.lana?.log('Campaign fetch failed, using mock data');
+      this.campaigns = MOCK_CAMPAIGNS;
     }
     this.loading = false;
   }

--- a/ecc/blocks/campaign-management-table/campaign-management-table.js
+++ b/ecc/blocks/campaign-management-table/campaign-management-table.js
@@ -1,0 +1,427 @@
+import { LIBS } from '../../scripts/scripts.js';
+import {
+  createCampaign,
+  getCampaigns,
+  updateCampaign,
+  deleteCampaign,
+} from '../../scripts/esp-controller.js';
+import { getIcon, buildNoAccessScreen, signIn } from '../../scripts/utils.js';
+import { initProfileLogicTree } from '../../scripts/profile.js';
+
+const { LitElement, html, repeat, nothing } = await import(`${LIBS}/deps/lit-all.min.js`);
+
+const SPECTRUM_COMPONENTS = [
+  'theme',
+  'button',
+  'dialog',
+  'underlay',
+  'textfield',
+  'switch',
+  'progress-circle',
+  'action-button',
+  'toast',
+  'tooltip',
+  'overlay',
+  'popover',
+  'field-label',
+  'number-field',
+  'divider',
+];
+
+class CampaignTable extends LitElement {
+  static properties = {
+    eventId: { type: String },
+    campaigns: { type: Array },
+    loading: { type: Boolean },
+    editingCampaign: { type: Object },
+    deletingCampaign: { type: Object },
+    showCreateDialog: { type: Boolean },
+    toastMsg: { type: String },
+    toastVariant: { type: String },
+    eventAttendeeLimit: { type: Number },
+  };
+
+  constructor() {
+    super();
+    this.campaigns = [];
+    this.loading = true;
+    this.editingCampaign = null;
+    this.deletingCampaign = null;
+    this.showCreateDialog = false;
+    this.toastMsg = '';
+    this.toastVariant = 'info';
+    this.eventAttendeeLimit = 0;
+  }
+
+  createRenderRoot() {
+    return this;
+  }
+
+  async connectedCallback() {
+    super.connectedCallback();
+    await this.loadCampaigns();
+  }
+
+  async loadCampaigns() {
+    this.loading = true;
+    try {
+      const resp = await getCampaigns(this.eventId);
+      if (Array.isArray(resp)) {
+        this.campaigns = resp;
+      } else {
+        this.campaigns = [];
+      }
+    } catch {
+      this.campaigns = [];
+    }
+    this.loading = false;
+  }
+
+  get totalCampaigns() { return this.campaigns.length; }
+
+  get activeCampaigns() { return this.campaigns.filter((c) => c.status === 'Active').length; }
+
+  get totalRegistrations() {
+    return this.campaigns.reduce((sum, c) => sum + (c.attendeeCount || 0), 0);
+  }
+
+  get totalAllocated() {
+    return this.campaigns.reduce((sum, c) => sum + (c.attendeeLimit || 0), 0);
+  }
+
+  get availableCapacity() {
+    return Math.max(0, this.eventAttendeeLimit - this.totalAllocated);
+  }
+
+  showToast(msg, variant = 'info') {
+    this.toastMsg = msg;
+    this.toastVariant = variant;
+    setTimeout(() => { this.toastMsg = ''; }, 4000);
+  }
+
+  async copyToClipboard(text) {
+    try {
+      await navigator.clipboard.writeText(text);
+      this.showToast('Copied to clipboard');
+    } catch {
+      this.showToast('Failed to copy', 'negative');
+    }
+  }
+
+  extractUrlParam(campaign) {
+    if (!campaign.url) return '';
+    try {
+      const url = new URL(campaign.url);
+      return url.searchParams.get('campaign') || campaign.campaignId || '';
+    } catch {
+      return campaign.campaignId || '';
+    }
+  }
+
+  openCreateDialog() { this.showCreateDialog = true; }
+
+  closeCreateDialog() { this.showCreateDialog = false; }
+
+  openEditDialog(campaign) { this.editingCampaign = { ...campaign }; }
+
+  closeEditDialog() { this.editingCampaign = null; }
+
+  openDeleteDialog(campaign) { this.deletingCampaign = campaign; }
+
+  closeDeleteDialog() { this.deletingCampaign = null; }
+
+  async handleCreate(e) {
+    e.preventDefault();
+    const form = this.querySelector('.create-dialog');
+    const name = form.querySelector('[name="name"]')?.value?.trim();
+    const attendeeLimit = parseInt(form.querySelector('[name="attendeeLimit"]')?.value, 10);
+
+    if (!name) return;
+
+    const payload = { name };
+    if (!Number.isNaN(attendeeLimit) && attendeeLimit > 0) {
+      payload.attendeeLimit = attendeeLimit;
+    }
+
+    const resp = await createCampaign(this.eventId, payload);
+    if (resp.error) {
+      const msg = resp.status === 409
+        ? 'Campaign capacity exceeds available event capacity.'
+        : 'Failed to create campaign.';
+      this.showToast(msg, 'negative');
+      return;
+    }
+
+    this.closeCreateDialog();
+    await this.loadCampaigns();
+    this.showToast('Campaign created successfully', 'positive');
+  }
+
+  async handleUpdate(e) {
+    e.preventDefault();
+    const form = this.querySelector('.edit-dialog');
+    const name = form.querySelector('[name="name"]')?.value?.trim();
+    const statusSwitch = form.querySelector('[name="status"]');
+    const status = statusSwitch?.checked ? 'Active' : 'Archived';
+
+    if (!name) return;
+
+    const payload = { name, status };
+
+    const resp = await updateCampaign(
+      this.eventId,
+      this.editingCampaign.campaignId,
+      payload,
+    );
+
+    if (resp.error) {
+      const msg = resp.status === 409
+        ? 'Campaign was modified by another user. Please refresh and try again.'
+        : 'Failed to update campaign.';
+      this.showToast(msg, 'negative');
+      return;
+    }
+
+    this.closeEditDialog();
+    await this.loadCampaigns();
+    this.showToast('Campaign updated successfully', 'positive');
+  }
+
+  async handleDelete() {
+    const { campaignId, name } = this.deletingCampaign;
+    const resp = await deleteCampaign(this.eventId, campaignId);
+
+    if (resp.error) {
+      const msg = resp.status === 400
+        ? `Cannot delete "${name}" because it has registered attendees.`
+        : `Failed to delete campaign "${name}".`;
+      this.showToast(msg, 'negative');
+      this.closeDeleteDialog();
+      return;
+    }
+
+    this.closeDeleteDialog();
+    await this.loadCampaigns();
+    this.showToast(`Campaign "${name}" deleted`, 'positive');
+  }
+
+  renderStats() {
+    return html`
+      <div class="campaign-stats">
+        <div class="stat">
+          <span class="stat-label">TOTAL CAMPAIGNS</span>
+          <span class="stat-value">${this.totalCampaigns}</span>
+        </div>
+        <div class="stat">
+          <span class="stat-label">ACTIVE</span>
+          <span class="stat-value">${this.activeCampaigns}</span>
+        </div>
+        <div class="stat">
+          <span class="stat-label">CAMPAIGN REGISTRATIONS</span>
+          <span class="stat-value">${this.totalRegistrations}</span>
+        </div>
+        <div class="stat">
+          <span class="stat-label">AVAILABLE CAPACITY</span>
+          <span class="stat-value">${this.availableCapacity}
+            <span class="stat-subtext">of ${this.eventAttendeeLimit} total</span>
+          </span>
+        </div>
+      </div>`;
+  }
+
+  renderTable() {
+    if (!this.campaigns.length) {
+      return html`<div class="empty-state">
+        <p>No campaigns yet. Create one to get started.</p>
+      </div>`;
+    }
+
+    return html`
+      <div class="campaign-table-wrapper">
+        <table class="campaign-table">
+          <thead>
+            <tr>
+              <th>CAMPAIGN NAME</th>
+              <th>URL PARAM</th>
+              <th>REGISTRATIONS</th>
+              <th>STATUS</th>
+              <th class="actions-col"></th>
+            </tr>
+          </thead>
+          <tbody>
+            ${repeat(this.campaigns, (c) => c.campaignId, (c) => html`
+              <tr>
+                <td class="campaign-name-cell">${c.name}</td>
+                <td class="url-param-cell">
+                  <span class="url-param-text">${this.extractUrlParam(c)}</span>
+                  <sp-action-button size="s" quiet label="Copy URL"
+                    @click=${() => this.copyToClipboard(c.url || '')}>
+                    <img src="/ecc/icons/copy.svg" slot="icon" alt="copy">
+                  </sp-action-button>
+                </td>
+                <td class="registrations-cell">
+                  ${c.attendeeCount || 0}${c.attendeeLimit ? html` / ${c.attendeeLimit}` : nothing}
+                </td>
+                <td>
+                  <span class="status-badge ${c.status === 'Active' ? 'active' : 'archived'}">
+                    ${c.status === 'Active' ? 'Active' : 'Inactive'}
+                  </span>
+                </td>
+                <td class="actions-col">
+                  <sp-action-button size="s" quiet label="Edit"
+                    @click=${() => this.openEditDialog(c)}>
+                    <img src="/ecc/icons/edit.svg" slot="icon" alt="edit">
+                  </sp-action-button>
+                  <sp-action-button size="s" quiet label="Delete"
+                    @click=${() => this.openDeleteDialog(c)}>
+                    <img src="/ecc/icons/delete.svg" slot="icon" alt="delete">
+                  </sp-action-button>
+                </td>
+              </tr>
+            `)}
+          </tbody>
+        </table>
+      </div>`;
+  }
+
+  renderCreateDialog() {
+    if (!this.showCreateDialog) return nothing;
+    return html`
+      <sp-underlay open></sp-underlay>
+      <div class="campaign-dialog create-dialog">
+        <h2>Add tracking link</h2>
+        <sp-divider size="s"></sp-divider>
+        <div class="dialog-body">
+          <div class="field-row">
+            <sp-field-label for="create-name" required>Name</sp-field-label>
+            <sp-textfield id="create-name" name="name" placeholder="Campaign name" required></sp-textfield>
+          </div>
+          <div class="field-row">
+            <sp-field-label for="create-limit">Set link capacity limit</sp-field-label>
+            <sp-textfield id="create-limit" name="attendeeLimit" type="number" placeholder="e.g. 50" min="1"></sp-textfield>
+            <span class="helper-text">Must be lower than the event capacity limit</span>
+          </div>
+        </div>
+        <div class="dialog-actions">
+          <sp-button variant="secondary" @click=${this.closeCreateDialog}>Cancel</sp-button>
+          <sp-button variant="accent" @click=${(e) => this.handleCreate(e)}>Save</sp-button>
+        </div>
+      </div>`;
+  }
+
+  renderEditDialog() {
+    if (!this.editingCampaign) return nothing;
+    const c = this.editingCampaign;
+    return html`
+      <sp-underlay open></sp-underlay>
+      <div class="campaign-dialog edit-dialog">
+        <h2>Edit tracking link</h2>
+        <sp-divider size="s"></sp-divider>
+        <div class="dialog-body">
+          <div class="field-row">
+            <sp-field-label for="edit-name" required>Name</sp-field-label>
+            <sp-textfield id="edit-name" name="name" value=${c.name} required></sp-textfield>
+          </div>
+          <div class="field-row">
+            <sp-field-label>Tracking link</sp-field-label>
+            <div class="tracking-link-row">
+              <span class="tracking-link-text">${c.url || ''}</span>
+              <sp-action-button size="s" quiet label="Copy link"
+                @click=${() => this.copyToClipboard(c.url || '')}>
+                <img src="/ecc/icons/copy.svg" slot="icon" alt="copy">
+              </sp-action-button>
+            </div>
+          </div>
+          <div class="field-row">
+            <sp-field-label>Set link capacity limit</sp-field-label>
+            <sp-textfield name="attendeeLimit" value=${c.attendeeLimit || ''} disabled></sp-textfield>
+          </div>
+          <div class="field-row switch-row">
+            <sp-switch name="status" ?checked=${c.status === 'Active'}>Active</sp-switch>
+            <span class="helper-text">Link is accepting registrations</span>
+          </div>
+        </div>
+        <div class="dialog-actions">
+          <sp-button variant="secondary" @click=${this.closeEditDialog}>Cancel</sp-button>
+          <sp-button variant="accent" @click=${(e) => this.handleUpdate(e)}>Save</sp-button>
+        </div>
+      </div>`;
+  }
+
+  renderDeleteDialog() {
+    if (!this.deletingCampaign) return nothing;
+    return html`
+      <sp-underlay open></sp-underlay>
+      <div class="campaign-dialog delete-dialog">
+        <h2>Delete Campaign</h2>
+        <sp-divider size="s"></sp-divider>
+        <div class="dialog-body">
+          <p>Are you sure you want to delete the campaign "${this.deletingCampaign.name}"?
+          This will not affect existing registrations, but the campaign URL will no longer work.</p>
+        </div>
+        <div class="dialog-actions">
+          <sp-button variant="secondary" @click=${this.closeDeleteDialog}>Cancel</sp-button>
+          <sp-button variant="negative" @click=${() => this.handleDelete()}>Delete</sp-button>
+        </div>
+      </div>`;
+  }
+
+  renderToast() {
+    if (!this.toastMsg) return nothing;
+    return html`<sp-toast open variant=${this.toastVariant} timeout="4000">${this.toastMsg}</sp-toast>`;
+  }
+
+  render() {
+    if (this.loading) {
+      return html`
+        <div class="loading-screen">
+          <sp-progress-circle size="l" indeterminate></sp-progress-circle>
+        </div>`;
+    }
+
+    return html`
+      ${this.renderStats()}
+      <div class="campaign-actions-bar">
+        <sp-button variant="accent" size="m" @click=${this.openCreateDialog}>
+          + Add Campaign
+        </sp-button>
+      </div>
+      ${this.renderTable()}
+      ${this.renderCreateDialog()}
+      ${this.renderEditDialog()}
+      ${this.renderDeleteDialog()}
+      <div class="toast-area">${this.renderToast()}</div>
+    `;
+  }
+}
+
+customElements.define('campaign-table', CampaignTable);
+
+export default async function init(el) {
+  const miloLibs = LIBS;
+  const promises = SPECTRUM_COMPONENTS.map(
+    (component) => import(`${miloLibs}/features/spectrum-web-components/dist/${component}.js`),
+  );
+  await Promise.all([
+    import(`${miloLibs}/deps/lit-all.min.js`),
+    ...promises,
+  ]);
+
+  el.innerHTML = '';
+
+  const eventId = new URLSearchParams(window.location.search).get('eventId');
+  if (!eventId) {
+    el.textContent = 'No event ID provided.';
+    return;
+  }
+
+  await initProfileLogicTree('campaign-management-table', {
+    noProfile: () => { signIn(); },
+    noAccessProfile: () => { buildNoAccessScreen(el); },
+    validProfile: () => {
+      const table = document.createElement('campaign-table');
+      table.eventId = eventId;
+      el.appendChild(table);
+    },
+  });
+}

--- a/ecc/blocks/campaign-management-table/campaign-management-table.js
+++ b/ecc/blocks/campaign-management-table/campaign-management-table.js
@@ -446,6 +446,12 @@ export default async function init(el) {
 
   el.innerHTML = '';
 
+  const spTheme = document.createElement('sp-theme');
+  spTheme.setAttribute('color', 'light');
+  spTheme.setAttribute('scale', 'medium');
+  el.parentElement.replaceChild(spTheme, el);
+  spTheme.appendChild(el);
+
   const eventId = new URLSearchParams(window.location.search).get('eventId');
   if (!eventId) {
     el.textContent = 'No event ID provided.';

--- a/ecc/blocks/campaign-management-table/campaign-management-table.js
+++ b/ecc/blocks/campaign-management-table/campaign-management-table.js
@@ -291,7 +291,7 @@ class CampaignTable extends LitElement {
                 <td class="campaign-name-cell">${c.name}</td>
                 <td class="url-param-cell">
                   <span class="url-param-text">${this.extractUrlParam(c)}</span>
-                  <sp-action-button size="s" quiet label="Copy URL"
+                  <sp-action-button size="xl" quiet label="Copy URL"
                     @click=${() => this.copyToClipboard(c.url || '')}>
                     <img src="/ecc/icons/copy.svg" slot="icon" alt="copy">
                   </sp-action-button>
@@ -305,11 +305,11 @@ class CampaignTable extends LitElement {
                   </span>
                 </td>
                 <td class="actions-col">
-                  <sp-action-button size="s" quiet label="Edit"
+                  <sp-action-button size="xl" quiet label="Edit"
                     @click=${() => this.openEditDialog(c)}>
                     <img src="/ecc/icons/edit.svg" slot="icon" alt="edit">
                   </sp-action-button>
-                  <sp-action-button size="s" quiet label="Delete"
+                  <sp-action-button size="xl" quiet label="Delete"
                     @click=${() => this.openDeleteDialog(c)}>
                     <img src="/ecc/icons/delete.svg" slot="icon" alt="delete">
                   </sp-action-button>
@@ -363,7 +363,7 @@ class CampaignTable extends LitElement {
             <sp-field-label>Tracking link</sp-field-label>
             <div class="tracking-link-row">
               <span class="tracking-link-text">${c.url || ''}</span>
-              <sp-action-button size="s" quiet label="Copy link"
+              <sp-action-button size="xl" quiet label="Copy link"
                 @click=${() => this.copyToClipboard(c.url || '')}>
                 <img src="/ecc/icons/copy.svg" slot="icon" alt="copy">
               </sp-action-button>

--- a/ecc/blocks/campaign-management-table/campaign-management-table.js
+++ b/ecc/blocks/campaign-management-table/campaign-management-table.js
@@ -2,6 +2,7 @@ import { LIBS } from '../../scripts/scripts.js';
 import {
   createCampaign,
   getCampaigns,
+  getEvent,
   updateCampaign,
   deleteCampaign,
 } from '../../scripts/esp-controller.js';
@@ -37,7 +38,7 @@ class CampaignTable extends LitElement {
     showCreateDialog: { type: Boolean },
     toastMsg: { type: String },
     toastVariant: { type: String },
-    eventAttendeeLimit: { type: Number },
+    useNoLimitToggle: { type: Boolean },
   };
 
   constructor() {
@@ -49,7 +50,7 @@ class CampaignTable extends LitElement {
     this.showCreateDialog = false;
     this.toastMsg = '';
     this.toastVariant = 'info';
-    this.eventAttendeeLimit = 0;
+    this.useNoLimitToggle = false;
   }
 
   createRenderRoot() {
@@ -86,14 +87,6 @@ class CampaignTable extends LitElement {
     return this.campaigns.reduce((sum, c) => sum + (c.attendeeCount || 0), 0);
   }
 
-  get totalAllocated() {
-    return this.campaigns.reduce((sum, c) => sum + (c.attendeeLimit || 0), 0);
-  }
-
-  get availableCapacity() {
-    return Math.max(0, this.eventAttendeeLimit - this.totalAllocated);
-  }
-
   showToast(msg, variant = 'info') {
     this.toastMsg = msg;
     this.toastVariant = variant;
@@ -119,7 +112,10 @@ class CampaignTable extends LitElement {
     }
   }
 
-  openCreateDialog() { this.showCreateDialog = true; }
+  openCreateDialog() {
+    this.showCreateDialog = true;
+    this.useNoLimitToggle = false;
+  }
 
   closeCreateDialog() { this.showCreateDialog = false; }
 
@@ -135,21 +131,31 @@ class CampaignTable extends LitElement {
     e.preventDefault();
     const form = this.querySelector('.create-dialog');
     const name = form.querySelector('[name="name"]')?.value?.trim();
-    const attendeeLimit = parseInt(form.querySelector('[name="attendeeLimit"]')?.value, 10);
 
     if (!name) return;
 
     const payload = { name };
-    if (!Number.isNaN(attendeeLimit) && attendeeLimit > 0) {
-      payload.attendeeLimit = attendeeLimit;
+
+    if (this.useNoLimitToggle) {
+      const eventResp = await getEvent(this.eventId);
+      if (eventResp?.error) {
+        this.showToast('Failed to load event. Please try again.', 'negative');
+        return;
+      }
+      const eventLimit = eventResp.attendeeLimit;
+      if (eventLimit != null && !Number.isNaN(+eventLimit) && +eventLimit > 0) {
+        payload.attendeeLimit = +eventLimit;
+      }
+    } else {
+      const attendeeLimit = parseInt(form.querySelector('[name="attendeeLimit"]')?.value, 10);
+      if (!Number.isNaN(attendeeLimit) && attendeeLimit > 0) {
+        payload.attendeeLimit = attendeeLimit;
+      }
     }
 
     const resp = await createCampaign(this.eventId, payload);
     if (resp.error) {
-      const msg = resp.status === 409
-        ? 'Campaign capacity exceeds available event capacity.'
-        : 'Failed to create campaign.';
-      this.showToast(msg, 'negative');
+      this.showToast('Failed to create campaign.', 'negative');
       return;
     }
 
@@ -220,12 +226,6 @@ class CampaignTable extends LitElement {
         <div class="stat">
           <span class="stat-label">CAMPAIGN REGISTRATIONS</span>
           <span class="stat-value">${this.totalRegistrations}</span>
-        </div>
-        <div class="stat">
-          <span class="stat-label">AVAILABLE CAPACITY</span>
-          <span class="stat-value">${this.availableCapacity}
-            <span class="stat-subtext">of ${this.eventAttendeeLimit} total</span>
-          </span>
         </div>
       </div>`;
   }
@@ -299,8 +299,11 @@ class CampaignTable extends LitElement {
           </div>
           <div class="field-row">
             <sp-field-label for="create-limit">Set link capacity limit</sp-field-label>
-            <input id="create-limit" name="attendeeLimit" type="number" placeholder="e.g. 50" min="1" class="capacity-input">
-            <span class="helper-text">Must be lower than the event capacity limit</span>
+            <input id="create-limit" name="attendeeLimit" type="number" placeholder="e.g. 50" min="1" class="capacity-input" ?disabled=${this.useNoLimitToggle}>
+          </div>
+          <div class="field-row switch-row">
+            <sp-switch name="useNoLimit" ?checked=${this.useNoLimitToggle}
+              @change=${(e) => { this.useNoLimitToggle = e.target.checked; }}>Use full event capacity (no limit)</sp-switch>
           </div>
         </div>
         <div class="dialog-actions">

--- a/ecc/blocks/campaign-management-table/campaign-management-table.js
+++ b/ecc/blocks/campaign-management-table/campaign-management-table.js
@@ -24,7 +24,6 @@ const SPECTRUM_COMPONENTS = [
   'overlay',
   'popover',
   'field-label',
-  'number-field',
   'divider',
 ];
 
@@ -298,7 +297,7 @@ class CampaignTable extends LitElement {
           </div>
           <div class="field-row">
             <sp-field-label for="create-limit">Set link capacity limit</sp-field-label>
-            <sp-textfield id="create-limit" name="attendeeLimit" type="number" placeholder="e.g. 50" min="1"></sp-textfield>
+            <input id="create-limit" name="attendeeLimit" type="number" placeholder="e.g. 50" min="1" class="capacity-input">
             <span class="helper-text">Must be lower than the event capacity limit</span>
           </div>
         </div>
@@ -334,7 +333,7 @@ class CampaignTable extends LitElement {
           </div>
           <div class="field-row">
             <sp-field-label>Set link capacity limit</sp-field-label>
-            <sp-textfield name="attendeeLimit" value=${c.attendeeLimit || ''} disabled></sp-textfield>
+            <input name="attendeeLimit" type="number" value=${c.attendeeLimit || ''} disabled class="capacity-input">
           </div>
           <div class="field-row switch-row">
             <sp-switch name="status" ?checked=${c.status === 'Active'}>Active</sp-switch>

--- a/ecc/blocks/campaign-management-table/campaign-management-table.js
+++ b/ecc/blocks/campaign-management-table/campaign-management-table.js
@@ -180,7 +180,7 @@ class CampaignTable extends LitElement {
       return;
     }
 
-    const ok = await this.performUpdate(this.editingCampaign.campaignId, { name, status });
+    const ok = await this.submitCampaignUpdate(this.editingCampaign.campaignId, { name, status });
     if (ok) {
       this.closeEditDialog();
       await this.loadCampaigns();
@@ -194,7 +194,7 @@ class CampaignTable extends LitElement {
 
   async handleConfirmInactive() {
     const { campaignId, name, status } = this.deactivatingCampaign;
-    const ok = await this.performUpdate(campaignId, { name, status });
+    const ok = await this.submitCampaignUpdate(campaignId, { name, status });
     if (ok) {
       this.closeInactiveConfirmDialog();
       this.closeEditDialog();
@@ -203,7 +203,7 @@ class CampaignTable extends LitElement {
     }
   }
 
-  async performUpdate(campaignId, payload) {
+  async submitCampaignUpdate(campaignId, payload) {
     const resp = await updateCampaign(this.eventId, campaignId, payload);
 
     if (resp.error) {

--- a/ecc/blocks/campaign-management-table/campaign-management-table.js
+++ b/ecc/blocks/campaign-management-table/campaign-management-table.js
@@ -35,6 +35,7 @@ class CampaignTable extends LitElement {
     loading: { type: Boolean },
     editingCampaign: { type: Object },
     deletingCampaign: { type: Object },
+    deactivatingCampaign: { type: Object },
     showCreateDialog: { type: Boolean },
     toastMsg: { type: String },
     toastVariant: { type: String },
@@ -47,6 +48,7 @@ class CampaignTable extends LitElement {
     this.loading = true;
     this.editingCampaign = null;
     this.deletingCampaign = null;
+    this.deactivatingCampaign = null;
     this.showCreateDialog = false;
     this.toastMsg = '';
     this.toastVariant = 'info';
@@ -173,25 +175,45 @@ class CampaignTable extends LitElement {
 
     if (!name) return;
 
-    const payload = { name, status };
+    if (status === 'Archived' && this.editingCampaign.status === 'Active') {
+      this.deactivatingCampaign = { ...this.editingCampaign, name, status };
+      return;
+    }
 
-    const resp = await updateCampaign(
-      this.eventId,
-      this.editingCampaign.campaignId,
-      payload,
-    );
+    const ok = await this.performUpdate(this.editingCampaign.campaignId, { name, status });
+    if (ok) {
+      this.closeEditDialog();
+      await this.loadCampaigns();
+      this.showToast('Campaign updated successfully', 'positive');
+    }
+  }
+
+  closeInactiveConfirmDialog() {
+    this.deactivatingCampaign = null;
+  }
+
+  async handleConfirmInactive() {
+    const { campaignId, name, status } = this.deactivatingCampaign;
+    const ok = await this.performUpdate(campaignId, { name, status });
+    if (ok) {
+      this.closeInactiveConfirmDialog();
+      this.closeEditDialog();
+      await this.loadCampaigns();
+      this.showToast('Campaign updated successfully', 'positive');
+    }
+  }
+
+  async performUpdate(campaignId, payload) {
+    const resp = await updateCampaign(this.eventId, campaignId, payload);
 
     if (resp.error) {
       const msg = resp.status === 409
         ? 'Campaign was modified by another user. Please refresh and try again.'
         : 'Failed to update campaign.';
       this.showToast(msg, 'negative');
-      return;
+      return false;
     }
-
-    this.closeEditDialog();
-    await this.loadCampaigns();
-    this.showToast('Campaign updated successfully', 'positive');
+    return true;
   }
 
   async handleDelete() {
@@ -255,10 +277,12 @@ class CampaignTable extends LitElement {
                 <td class="campaign-name-cell">${c.name}</td>
                 <td class="url-param-cell">
                   <span class="url-param-text">${CampaignTable.extractUrlParam(c)}</span>
+                  ${c.url ? html`
                   <sp-action-button size="xl" quiet label="Copy URL"
-                    @click=${() => this.copyToClipboard(c.url || '')}>
+                    @click=${() => this.copyToClipboard(c.url)}>
                     <img src="/ecc/icons/copy.svg" slot="icon" alt="copy">
                   </sp-action-button>
+                  ` : nothing}
                 </td>
                 <td class="registrations-cell">
                   ${c.attendeeCount || 0}${c.attendeeLimit ? html` / ${c.attendeeLimit}` : nothing}
@@ -269,10 +293,12 @@ class CampaignTable extends LitElement {
                   </span>
                 </td>
                 <td class="actions-col">
+                  ${c.status === 'Active' ? html`
                   <sp-action-button size="xl" quiet label="Edit"
                     @click=${() => this.openEditDialog(c)}>
                     <img src="/ecc/icons/edit.svg" slot="icon" alt="edit">
                   </sp-action-button>
+                  ` : nothing}
                   <sp-action-button size="xl" quiet label="Delete"
                     @click=${() => this.openDeleteDialog(c)}>
                     <img src="/ecc/icons/delete.svg" slot="icon" alt="delete">
@@ -330,10 +356,12 @@ class CampaignTable extends LitElement {
             <sp-field-label>Tracking link</sp-field-label>
             <div class="tracking-link-row">
               <span class="tracking-link-text">${c.url || ''}</span>
+              ${c.url ? html`
               <sp-action-button size="xl" quiet label="Copy link"
-                @click=${() => this.copyToClipboard(c.url || '')}>
+                @click=${() => this.copyToClipboard(c.url)}>
                 <img src="/ecc/icons/copy.svg" slot="icon" alt="copy">
               </sp-action-button>
+              ` : nothing}
             </div>
           </div>
           <div class="field-row">
@@ -348,6 +376,24 @@ class CampaignTable extends LitElement {
         <div class="dialog-actions">
           <sp-button variant="secondary" @click=${this.closeEditDialog}>Cancel</sp-button>
           <sp-button variant="accent" @click=${(e) => this.handleUpdate(e)}>Save</sp-button>
+        </div>
+      </div>`;
+  }
+
+  renderInactiveConfirmDialog() {
+    if (!this.deactivatingCampaign) return nothing;
+    return html`
+      <sp-underlay open></sp-underlay>
+      <div class="campaign-dialog inactive-confirm-dialog">
+        <h2>Make Campaign Inactive</h2>
+        <sp-divider size="s"></sp-divider>
+        <div class="dialog-body">
+          <p>Making this campaign inactive is <strong>permanent</strong>. Once inactive, the campaign cannot be reactivated. The tracking link will no longer accept new registrations. Existing registrations are not affected.</p>
+          <p>Are you sure you want to make this campaign inactive?</p>
+        </div>
+        <div class="dialog-actions">
+          <sp-button variant="secondary" @click=${this.closeInactiveConfirmDialog}>Cancel</sp-button>
+          <sp-button variant="negative" @click=${() => this.handleConfirmInactive()}>Make inactive</sp-button>
         </div>
       </div>`;
   }
@@ -393,6 +439,7 @@ class CampaignTable extends LitElement {
       ${this.renderTable()}
       ${this.renderCreateDialog()}
       ${this.renderEditDialog()}
+      ${this.renderInactiveConfirmDialog()}
       ${this.renderDeleteDialog()}
       <div class="toast-area">${this.renderToast()}</div>
     `;

--- a/ecc/blocks/campaign-management-table/campaign-management-table.js
+++ b/ecc/blocks/campaign-management-table/campaign-management-table.js
@@ -27,42 +27,6 @@ const SPECTRUM_COMPONENTS = [
   'divider',
 ];
 
-const MOCK_CAMPAIGNS = [
-  {
-    campaignId: 'mock-1',
-    name: 'Partner Promotion',
-    status: 'Active',
-    attendeeLimit: 50,
-    attendeeCount: 23,
-    waitlistAttendeeCount: 0,
-    url: 'https://www.adobe.com/events/example?campaign=partner-promo',
-    creationTime: Date.now(),
-    modificationTime: Date.now(),
-  },
-  {
-    campaignId: 'mock-2',
-    name: 'Email Newsletter',
-    status: 'Active',
-    attendeeLimit: 100,
-    attendeeCount: 67,
-    waitlistAttendeeCount: 0,
-    url: 'https://www.adobe.com/events/example?campaign=email-newsletter',
-    creationTime: Date.now(),
-    modificationTime: Date.now(),
-  },
-  {
-    campaignId: 'mock-3',
-    name: 'Social Media',
-    status: 'Archived',
-    attendeeLimit: 0,
-    attendeeCount: 45,
-    waitlistAttendeeCount: 0,
-    url: 'https://www.adobe.com/events/example?campaign=social',
-    creationTime: Date.now(),
-    modificationTime: Date.now(),
-  },
-];
-
 class CampaignTable extends LitElement {
   static properties = {
     eventId: { type: String },
@@ -104,12 +68,12 @@ class CampaignTable extends LitElement {
       if (Array.isArray(resp)) {
         this.campaigns = resp;
       } else {
-        window.lana?.log('Campaign fetch did not return an array, using mock data');
-        this.campaigns = MOCK_CAMPAIGNS;
+        window.lana?.log('Campaign fetch did not return an array');
+        this.campaigns = [];
       }
-    } catch {
-      window.lana?.log('Campaign fetch failed, using mock data');
-      this.campaigns = MOCK_CAMPAIGNS;
+    } catch (err) {
+      window.lana?.log('Campaign fetch failed', err);
+      this.campaigns = [];
     }
     this.loading = false;
   }

--- a/ecc/blocks/ecc-dashboard/ecc-dashboard.js
+++ b/ecc/blocks/ecc-dashboard/ecc-dashboard.js
@@ -491,7 +491,7 @@ function initMoreOptions(props, config, eventObj, row) {
     edit.href = url.toString();
 
     // campaigns
-    const campaignsUrl = new URL(`${window.location.origin}${config['campaign-dashboard-url'] || '/ecc/campaign-management-table'}`);
+    const campaignsUrl = new URL(`${window.location.origin}${config['campaign-dashboard-url'] || '/ecc/dashboard/t3/campaigns'}`);
     campaignsUrl.searchParams.set('eventId', eventObj.eventId);
     campaigns.href = campaignsUrl.toString();
 

--- a/ecc/blocks/ecc-dashboard/ecc-dashboard.js
+++ b/ecc/blocks/ecc-dashboard/ecc-dashboard.js
@@ -25,7 +25,9 @@ import {
 import { initProfileLogicTree } from '../../scripts/profile.js';
 import { cloneFilter, eventObjFilter } from './dashboard-utils.js';
 import { getAttribute, setEventAttribute } from '../../scripts/data-utils.js';
-import { EVENT_TYPES } from '../../scripts/constants.js';
+import { EVENT_TYPES, ENVIRONMENTS } from '../../scripts/constants.js';
+import { getCurrentEnvironment } from '../../scripts/environment.js';
+import { toStageOrigin } from '../../scripts/domain-mapping.js';
 
 // API Cache and Throttling System (functional approach)
 const apiCache = (() => {
@@ -425,14 +427,23 @@ function initMoreOptions(props, config, eventObj, row) {
     const deleteBtn = buildTool(toolBox, 'Delete', 'delete-wire-round');
 
     if (eventObj.detailPagePath) {
-      previewPre.href = (() => {
+      const resolvePreviewUrl = (detailPagePath) => {
         let url;
-
         try {
-          url = new URL(`${eventObj.detailPagePath}`);
+          url = new URL(detailPagePath);
         } catch (e) {
-          url = new URL(`${getEventPageHost()}${eventObj.detailPagePath}`);
+          url = new URL(`${getEventPageHost()}${detailPagePath}`);
         }
+
+        if (getCurrentEnvironment() !== ENVIRONMENTS.PROD) {
+          url = new URL(toStageOrigin(url.href));
+        }
+
+        return url;
+      };
+
+      previewPre.href = (() => {
+        const url = resolvePreviewUrl(eventObj.detailPagePath);
 
         if (url) {
           url.searchParams.set('previewMode', 'true');
@@ -445,12 +456,7 @@ function initMoreOptions(props, config, eventObj, row) {
       previewPre.target = '_blank';
 
       previewPost.href = (() => {
-        let url;
-        try {
-          url = new URL(`${eventObj.detailPagePath}`);
-        } catch (e) {
-          url = new URL(`${getEventPageHost()}${eventObj.detailPagePath}`);
-        }
+        const url = resolvePreviewUrl(eventObj.detailPagePath);
 
         if (url) {
           url.searchParams.set('previewMode', 'true');

--- a/ecc/blocks/ecc-dashboard/ecc-dashboard.js
+++ b/ecc/blocks/ecc-dashboard/ecc-dashboard.js
@@ -27,7 +27,7 @@ import { initProfileLogicTree } from '../../scripts/profile.js';
 import { cloneFilter, eventObjFilter } from './dashboard-utils.js';
 import { getAttribute, setEventAttribute } from '../../scripts/data-utils.js';
 import { EVENT_TYPES, ENVIRONMENTS } from '../../scripts/constants.js';
-import { getCurrentEnvironment } from '../../scripts/environment.js';
+import { getCurrentEnvironment, getEspEnvParam } from '../../scripts/environment.js';
 
 // API Cache and Throttling System (functional approach)
 const apiCache = (() => {
@@ -438,6 +438,9 @@ function initMoreOptions(props, config, eventObj, row) {
         if (getCurrentEnvironment() !== ENVIRONMENTS.PROD) {
           url = new URL(toStageOrigin(url.href));
         }
+
+        const espEnv = getEspEnvParam();
+        if (espEnv) url.searchParams.set('espenv', espEnv);
 
         return url;
       };

--- a/ecc/blocks/ecc-dashboard/ecc-dashboard.js
+++ b/ecc/blocks/ecc-dashboard/ecc-dashboard.js
@@ -21,13 +21,13 @@ import {
   signIn,
   isPublishingLocked,
 } from '../../scripts/utils.js';
+import { toStageOrigin } from '../../scripts/domain-mapping.js';
 
 import { initProfileLogicTree } from '../../scripts/profile.js';
 import { cloneFilter, eventObjFilter } from './dashboard-utils.js';
 import { getAttribute, setEventAttribute } from '../../scripts/data-utils.js';
 import { EVENT_TYPES, ENVIRONMENTS } from '../../scripts/constants.js';
 import { getCurrentEnvironment } from '../../scripts/environment.js';
-import { toStageOrigin } from '../../scripts/domain-mapping.js';
 
 // API Cache and Throttling System (functional approach)
 const apiCache = (() => {
@@ -446,8 +446,6 @@ function initMoreOptions(props, config, eventObj, row) {
         const url = resolvePreviewUrl(eventObj.detailPagePath);
 
         if (url) {
-          url.searchParams.set('previewMode', 'true');
-          url.searchParams.set('cachebuster', Date.now());
           url.searchParams.set('timing', +eventObj.localEndTimeMillis - 10);
           return url.toString();
         }
@@ -459,8 +457,6 @@ function initMoreOptions(props, config, eventObj, row) {
         const url = resolvePreviewUrl(eventObj.detailPagePath);
 
         if (url) {
-          url.searchParams.set('previewMode', 'true');
-          url.searchParams.set('cachebuster', Date.now());
           url.searchParams.set('timing', +eventObj.localEndTimeMillis + 10);
           return url.toString();
         }

--- a/ecc/blocks/ecc-dashboard/ecc-dashboard.js
+++ b/ecc/blocks/ecc-dashboard/ecc-dashboard.js
@@ -423,6 +423,7 @@ function initMoreOptions(props, config, eventObj, row) {
     const previewPost = buildTool(toolBox, 'Preview post-event', 'preview-eye');
     const copyUrl = buildTool(toolBox, 'Copy URL', 'copy');
     const edit = buildTool(toolBox, 'Edit', 'edit-pencil');
+    const campaigns = buildTool(toolBox, 'Campaigns', 'copy');
     const clone = buildTool(toolBox, 'Clone', 'clone');
     const deleteBtn = buildTool(toolBox, 'Delete', 'delete-wire-round');
 
@@ -488,6 +489,11 @@ function initMoreOptions(props, config, eventObj, row) {
     // edit
     const url = getEventEditUrl(config, eventObj);
     edit.href = url.toString();
+
+    // campaigns
+    const campaignsUrl = new URL(`${window.location.origin}${config['campaign-dashboard-url'] || '/ecc/campaign-management-table'}`);
+    campaignsUrl.searchParams.set('eventId', eventObj.eventId);
+    campaigns.href = campaignsUrl.toString();
 
     // clone
     clone.addEventListener('click', async (e) => {

--- a/ecc/blocks/form-handler/form-handler-helper.js
+++ b/ecc/blocks/form-handler/form-handler-helper.js
@@ -28,6 +28,7 @@ import {
   buildNoAccessScreen,
   generateToolTip,
   camelToSentenceCase,
+  getEventPageHost,
   getEventLibsHost,
   replaceAnchorWithButton,
   getMetadata,
@@ -47,6 +48,7 @@ import {
 } from '../../scripts/esp-controller.js';
 import { getAttribute } from '../../scripts/data-utils.js';
 import { ENVIRONMENTS, EVENT_TYPES, DEFAULT_SAVE_POLICIES } from '../../scripts/constants.js';
+import { toStageOrigin } from '../../scripts/domain-mapping.js';
 
 const { createTag } = await import(`${LIBS}/utils/utils.js`);
 const { decorateButtons } = await import(`${LIBS}/utils/decorate.js`);
@@ -1011,6 +1013,10 @@ function updateCtas(props) {
           previewUrl = new URL(eventDataResp.detailPagePath).href;
         } catch (e) {
           previewUrl = `${getEventPageHost()}${eventDataResp.detailPagePath}`;
+        }
+
+        if (getCurrentEnvironment() !== ENVIRONMENTS.PROD) {
+          previewUrl = toStageOrigin(previewUrl);
         }
 
         a.href = `${previewUrl}?previewMode=true&cachebuster=${Date.now()}&timing=${testTime}`;

--- a/ecc/blocks/form-handler/form-handler-helper.js
+++ b/ecc/blocks/form-handler/form-handler-helper.js
@@ -1019,7 +1019,7 @@ function updateCtas(props) {
           previewUrl = toStageOrigin(previewUrl);
         }
 
-        a.href = `${previewUrl}?previewMode=true&cachebuster=${Date.now()}&timing=${testTime}`;
+        a.href = `${previewUrl}?timing=${testTime}`;
         a.classList.remove('preview-not-ready');
       }
     }

--- a/ecc/blocks/form-handler/form-handler-helper.js
+++ b/ecc/blocks/form-handler/form-handler-helper.js
@@ -35,7 +35,7 @@ import {
   isPublishingLocked,
 } from '../../scripts/utils.js';
 
-import { getCurrentEnvironment } from '../../scripts/environment.js';
+import { getCurrentEnvironment, getEspEnvParam } from '../../scripts/environment.js';
 
 import {
   createEvent,
@@ -1010,16 +1010,21 @@ function updateCtas(props) {
         let previewUrl;
 
         try {
-          previewUrl = new URL(eventDataResp.detailPagePath).href;
+          previewUrl = new URL(eventDataResp.detailPagePath);
         } catch (e) {
-          previewUrl = `${getEventPageHost()}${eventDataResp.detailPagePath}`;
+          previewUrl = new URL(`${getEventPageHost()}${eventDataResp.detailPagePath}`);
         }
 
         if (getCurrentEnvironment() !== ENVIRONMENTS.PROD) {
-          previewUrl = toStageOrigin(previewUrl);
+          previewUrl = new URL(toStageOrigin(previewUrl.href));
         }
 
-        a.href = `${previewUrl}?timing=${testTime}`;
+        previewUrl.searchParams.set('timing', testTime);
+
+        const espEnv = getEspEnvParam();
+        if (espEnv) previewUrl.searchParams.set('espenv', espEnv);
+
+        a.href = previewUrl.toString();
         a.classList.remove('preview-not-ready');
       }
     }

--- a/ecc/scripts/domain-mapping.js
+++ b/ecc/scripts/domain-mapping.js
@@ -36,20 +36,17 @@ function isSuffixEntry(value) {
  * @returns {string|null} The mapped hostname, or null if no match
  */
 function mapHostname(hostname, fromKey, toKey) {
-  for (const entry of DOMAIN_MAP) {
+  return DOMAIN_MAP.reduce((matched, entry) => {
+    if (matched) return matched;
     const from = entry[fromKey];
     const to = entry[toKey];
 
-    if (isSuffixEntry(from)) {
-      if (hostname.endsWith(from)) {
-        return hostname.slice(0, -from.length) + to;
-      }
-    } else if (hostname === from) {
-      return to;
+    if (isSuffixEntry(from) && hostname.endsWith(from)) {
+      return hostname.slice(0, -from.length) + to;
     }
-  }
-
-  return null;
+    if (hostname === from) return to;
+    return null;
+  }, null);
 }
 
 /**

--- a/ecc/scripts/domain-mapping.js
+++ b/ecc/scripts/domain-mapping.js
@@ -1,0 +1,119 @@
+/**
+ * Stage/Prod domain prediction module.
+ *
+ * Provides bidirectional origin mapping between stage and production environments.
+ * Used for event preview page navigation to ensure URLs point to the correct
+ * environment across the dashboard and event creation form.
+ *
+ * @module domain-mapping
+ */
+
+/**
+ * Domain mapping pairs between stage and production.
+ *
+ * To add a new mapping, add an entry to this array:
+ * - Exact hostnames: { prod: 'example.com', stage: 'stage.example.com' }
+ * - Suffix patterns (values starting with '.'):
+ *   { prod: '.cdn.com', stage: '.cdn-stage.com' }
+ *
+ * Entries are matched top-to-bottom. First match wins.
+ */
+export const DOMAIN_MAP = [
+  { prod: 'www.adobe.com', stage: 'www.stage.adobe.com' },
+  { prod: 'business.adobe.com', stage: 'business.stage.adobe.com' },
+  { prod: '.aem.live', stage: '.aem.page' },
+];
+
+function isSuffixEntry(value) {
+  return value.startsWith('.');
+}
+
+/**
+ * Finds a matching map entry and returns the mapped hostname.
+ * @param {string} hostname - The hostname to look up
+ * @param {'prod'|'stage'} fromKey - The source direction
+ * @param {'prod'|'stage'} toKey - The target direction
+ * @returns {string|null} The mapped hostname, or null if no match
+ */
+function mapHostname(hostname, fromKey, toKey) {
+  for (const entry of DOMAIN_MAP) {
+    const from = entry[fromKey];
+    const to = entry[toKey];
+
+    if (isSuffixEntry(from)) {
+      if (hostname.endsWith(from)) {
+        return hostname.slice(0, -from.length) + to;
+      }
+    } else if (hostname === from) {
+      return to;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Transforms a URL, origin, or hostname between environments.
+ * Returns the input unchanged if no mapping matches.
+ * @param {string} input - A full URL, origin, or bare hostname
+ * @param {'prod'|'stage'} fromKey - The source direction
+ * @param {'prod'|'stage'} toKey - The target direction
+ * @returns {string} The transformed input
+ */
+function transformUrl(input, fromKey, toKey) {
+  if (!input) return input;
+
+  try {
+    const url = new URL(input);
+    const mapped = mapHostname(url.hostname, fromKey, toKey);
+    if (!mapped) return input;
+    return input.replace(url.hostname, mapped);
+  } catch {
+    const mapped = mapHostname(input, fromKey, toKey);
+    return mapped || input;
+  }
+}
+
+/**
+ * Transforms a URL, origin, or hostname to its stage equivalent.
+ * If the input is already a stage origin or doesn't match any mapping,
+ * it is returned unchanged.
+ *
+ * @param {string} input - A full URL, origin, or bare hostname
+ * @returns {string} The stage-equivalent input
+ *
+ * @example
+ * toStageOrigin('https://www.adobe.com')
+ * // => 'https://www.stage.adobe.com'
+ *
+ * toStageOrigin('https://main--site--org.aem.live/events/my-event')
+ * // => 'https://main--site--org.aem.page/events/my-event'
+ *
+ * toStageOrigin('www.adobe.com')
+ * // => 'www.stage.adobe.com'
+ */
+export function toStageOrigin(input) {
+  return transformUrl(input, 'prod', 'stage');
+}
+
+/**
+ * Transforms a URL, origin, or hostname to its production equivalent.
+ * If the input is already a production origin or doesn't match any mapping,
+ * it is returned unchanged.
+ *
+ * @param {string} input - A full URL, origin, or bare hostname
+ * @returns {string} The production-equivalent input
+ *
+ * @example
+ * toProdOrigin('https://www.stage.adobe.com')
+ * // => 'https://www.adobe.com'
+ *
+ * toProdOrigin('https://main--site--org.aem.page/events/my-event')
+ * // => 'https://main--site--org.aem.live/events/my-event'
+ *
+ * toProdOrigin('www.stage.adobe.com')
+ * // => 'www.adobe.com'
+ */
+export function toProdOrigin(input) {
+  return transformUrl(input, 'stage', 'prod');
+}

--- a/ecc/scripts/environment.js
+++ b/ecc/scripts/environment.js
@@ -166,6 +166,19 @@ export function getEventServiceHost(relativeDomain, location = window.location) 
  * @returns {string} The event service host URL
  * @throws {Error} If environment detection is not available
  */
+/**
+ * Returns the ESP environment identifier for use as a URL parameter.
+ * Maps LOCAL to DEV (same ESP host). Returns null for PROD (default).
+ * @param {Location} [location=window.location]
+ * @returns {string|null}
+ */
+export function getEspEnvParam(location = window.location) {
+  const env = getCurrentEnvironment(location);
+  if (env === ENVIRONMENTS.PROD) return null;
+  if (env === ENVIRONMENTS.LOCAL) return ENVIRONMENTS.DEV;
+  return env;
+}
+
 export function getDAHost(relativeDomain, location = window.location) {
   const currentEnv = getCurrentEnvironment(location);
   const { hostname, href, origin } = location;

--- a/ecc/scripts/esp-controller.js
+++ b/ecc/scripts/esp-controller.js
@@ -975,24 +975,44 @@ export async function deleteEvent(eventId) {
   }
 }
 
-export async function getEvents() {
-  const { host } = API_CONFIG.esp[getCurrentEnvironment()];
-  const options = await constructRequestOptions('GET');
-
-  try {
-    const response = await safeFetch(`${host}/v1/events`, options);
-    const data = await response.json();
-
-    if (!response.ok) {
-      window.lana?.log(`Failed to get list of events. Status: ${response.status}\nError: ${JSON.stringify(data, null, 2)}`);
-      return { status: response.status, error: data };
+async function getAllEvents() {
+  const recurGetEvents = async (fullEventsArr = [], nextPageToken = null) => {
+    const { host } = API_CONFIG.esp[getCurrentEnvironment()];
+    const options = await constructRequestOptions('GET');
+    const baseFetchUrl = `${host}/v1/events`;
+    const potentialUrlParams = new URLSearchParams();
+    if (nextPageToken) {
+      potentialUrlParams.set('next-page-token', nextPageToken);
     }
+    const fetchUrl = `${baseFetchUrl}?${potentialUrlParams.toString()}`;
 
-    return data;
-  } catch (error) {
-    window.lana?.log(`Failed to get list of events:\n${JSON.stringify(error, null, 2)}`);
-    return { status: 'Network Error', error: error.message };
-  }
+    try {
+      const response = await safeFetch(fetchUrl, options);
+      const data = await response.json();
+
+      if (!response.ok) {
+        window.lana?.log(`Failed to get list of events. Status: ${response.status}\nError: ${JSON.stringify(data, null, 2)}`);
+        return { status: response.status, error: data };
+      }
+
+      const allEvents = fullEventsArr.concat(data.events || []);
+
+      if (data.nextPageToken) {
+        return recurGetEvents(allEvents, data.nextPageToken);
+      }
+
+      return { events: allEvents };
+    } catch (error) {
+      window.lana?.log(`Failed to get list of events:\n${JSON.stringify(error, null, 2)}`);
+      return { status: 'Network Error', error: error.message };
+    }
+  };
+
+  return recurGetEvents();
+}
+
+export async function getEvents() {
+  return getAllEvents();
 }
 
 export async function getEventsForUser() {
@@ -1424,7 +1444,7 @@ export async function getAllEventAttendees(eventId) {
       potentialUrlParams.set('type', type);
     }
     if (nextPageToken) {
-      potentialUrlParams.set('nextPageToken', nextPageToken);
+      potentialUrlParams.set('next-page-token', nextPageToken);
     }
     const fetchUrl = `${baseFetchUrl}?${potentialUrlParams.toString()}`;
 

--- a/ecc/scripts/esp-controller.js
+++ b/ecc/scripts/esp-controller.js
@@ -1838,3 +1838,130 @@ export async function assignPublishingProfileToEvent(eventId, profileId) {
     return { status: 'Network Error', error: error.message };
   }
 }
+
+export async function createCampaign(eventId, campaignData) {
+  if (!eventId || typeof eventId !== 'string') throw new Error('Invalid event ID');
+  if (!campaignData || typeof campaignData !== 'object') throw new Error('Invalid campaign data');
+
+  const { host } = API_CONFIG.esp[getCurrentEnvironment()];
+  const raw = JSON.stringify(campaignData);
+  const options = await constructRequestOptions('POST', raw);
+
+  try {
+    const response = await safeFetch(`${host}/v1/events/${eventId}/campaigns`, options);
+    const data = await response.json();
+
+    if (!response.ok) {
+      window.lana?.log(`Failed to create campaign for event ${eventId}. Status: ${response.status}\nError: ${JSON.stringify(data, null, 2)}`);
+      return { status: response.status, error: data };
+    }
+
+    return data;
+  } catch (error) {
+    window.lana?.log(`Failed to create campaign for event ${eventId}:\n${JSON.stringify(error, null, 2)}`);
+    return { status: 'Network Error', error: error.message };
+  }
+}
+
+export async function getCampaigns(eventId) {
+  if (!eventId || typeof eventId !== 'string') throw new Error('Invalid event ID');
+
+  const { host } = API_CONFIG.esp[getCurrentEnvironment()];
+  const options = await constructRequestOptions('GET');
+
+  try {
+    const response = await safeFetch(`${host}/v1/events/${eventId}/campaigns`, options);
+    const data = await response.json();
+
+    if (!response.ok) {
+      window.lana?.log(`Failed to get campaigns for event ${eventId}. Status: ${response.status}\nError: ${JSON.stringify(data, null, 2)}`);
+      return { status: response.status, error: data };
+    }
+
+    return data.campaigns;
+  } catch (error) {
+    window.lana?.log(`Failed to get campaigns for event ${eventId}:\n${JSON.stringify(error, null, 2)}`);
+    return { status: 'Network Error', error: error.message };
+  }
+}
+
+export async function getCampaign(eventId, campaignId) {
+  if (!eventId || typeof eventId !== 'string') throw new Error('Invalid event ID');
+  if (!campaignId || typeof campaignId !== 'string') throw new Error('Invalid campaign ID');
+
+  const { host } = API_CONFIG.esp[getCurrentEnvironment()];
+  const options = await constructRequestOptions('GET');
+
+  try {
+    const response = await safeFetch(`${host}/v1/events/${eventId}/campaigns/${campaignId}`, options);
+    const data = await response.json();
+
+    if (!response.ok) {
+      window.lana?.log(`Failed to get campaign ${campaignId} for event ${eventId}. Status: ${response.status}\nError: ${JSON.stringify(data, null, 2)}`);
+      return { status: response.status, error: data };
+    }
+
+    return data;
+  } catch (error) {
+    window.lana?.log(`Failed to get campaign ${campaignId} for event ${eventId}:\n${JSON.stringify(error, null, 2)}`);
+    return { status: 'Network Error', error: error.message };
+  }
+}
+
+export async function updateCampaign(eventId, campaignId, campaignData) {
+  if (!eventId || typeof eventId !== 'string') throw new Error('Invalid event ID');
+  if (!campaignId || typeof campaignId !== 'string') throw new Error('Invalid campaign ID');
+  if (!campaignData || typeof campaignData !== 'object') throw new Error('Invalid campaign data');
+
+  const existingCampaign = await getCampaign(eventId, campaignId);
+  if (existingCampaign.error) {
+    window.lana?.log(`Failed to get campaign ${campaignId} for update. Status: ${existingCampaign.status}\nError: ${JSON.stringify(existingCampaign, null, 2)}`);
+    return { status: existingCampaign.status, error: existingCampaign.error };
+  }
+
+  const { host } = API_CONFIG.esp[getCurrentEnvironment()];
+  const updatedCampaignData = {
+    ...campaignData,
+    modificationTime: existingCampaign.modificationTime,
+  };
+  const raw = JSON.stringify(updatedCampaignData);
+  const options = await constructRequestOptions('PUT', raw);
+
+  try {
+    const response = await safeFetch(`${host}/v1/events/${eventId}/campaigns/${campaignId}`, options);
+    const data = await response.json();
+
+    if (!response.ok) {
+      window.lana?.log(`Failed to update campaign ${campaignId} for event ${eventId}. Status: ${response.status}\nError: ${JSON.stringify(data, null, 2)}`);
+      return { status: response.status, error: data };
+    }
+
+    return data;
+  } catch (error) {
+    window.lana?.log(`Failed to update campaign ${campaignId} for event ${eventId}:\n${JSON.stringify(error, null, 2)}`);
+    return { status: 'Network Error', error: error.message };
+  }
+}
+
+export async function deleteCampaign(eventId, campaignId) {
+  if (!eventId || typeof eventId !== 'string') throw new Error('Invalid event ID');
+  if (!campaignId || typeof campaignId !== 'string') throw new Error('Invalid campaign ID');
+
+  const { host } = API_CONFIG.esp[getCurrentEnvironment()];
+  const options = await constructRequestOptions('DELETE');
+
+  try {
+    const response = await safeFetch(`${host}/v1/events/${eventId}/campaigns/${campaignId}`, options);
+
+    if (response.ok) {
+      return { ok: true };
+    }
+
+    const data = await response.json();
+    window.lana?.log(`Failed to delete campaign ${campaignId} for event ${eventId}. Status: ${response.status}\nError: ${JSON.stringify(data, null, 2)}`);
+    return { status: response.status, error: data };
+  } catch (error) {
+    window.lana?.log(`Failed to delete campaign ${campaignId} for event ${eventId}:\n${JSON.stringify(error, null, 2)}`);
+    return { status: 'Network Error', error: error.message };
+  }
+}

--- a/test/scripts/domain-mapping.test.js
+++ b/test/scripts/domain-mapping.test.js
@@ -1,0 +1,177 @@
+import { expect } from '@esm-bundle/chai';
+import { DOMAIN_MAP, toStageOrigin, toProdOrigin } from '../../ecc/scripts/domain-mapping.js';
+
+describe('Domain Mapping Module', () => {
+  describe('DOMAIN_MAP', () => {
+    it('should be a non-empty array', () => {
+      expect(DOMAIN_MAP).to.be.an('array').that.is.not.empty;
+    });
+
+    it('should have prod and stage keys for every entry', () => {
+      DOMAIN_MAP.forEach((entry) => {
+        expect(entry).to.have.property('prod').that.is.a('string');
+        expect(entry).to.have.property('stage').that.is.a('string');
+      });
+    });
+  });
+
+  describe('toStageOrigin', () => {
+    it('should map www.adobe.com to www.stage.adobe.com', () => {
+      expect(toStageOrigin('https://www.adobe.com')).to.equal('https://www.stage.adobe.com');
+    });
+
+    it('should map www.adobe.com with a path', () => {
+      expect(toStageOrigin('https://www.adobe.com/events/my-event'))
+        .to.equal('https://www.stage.adobe.com/events/my-event');
+    });
+
+    it('should map business.adobe.com to business.stage.adobe.com', () => {
+      expect(toStageOrigin('https://business.adobe.com'))
+        .to.equal('https://business.stage.adobe.com');
+    });
+
+    it('should map business.adobe.com with a path', () => {
+      expect(toStageOrigin('https://business.adobe.com/events/summit'))
+        .to.equal('https://business.stage.adobe.com/events/summit');
+    });
+
+    it('should map .aem.live suffix to .aem.page', () => {
+      expect(toStageOrigin('https://main--da-events--adobecom.aem.live'))
+        .to.equal('https://main--da-events--adobecom.aem.page');
+    });
+
+    it('should map .aem.live with a path', () => {
+      expect(toStageOrigin('https://main--da-events--adobecom.aem.live/events/my-event'))
+        .to.equal('https://main--da-events--adobecom.aem.page/events/my-event');
+    });
+
+    it('should handle various AEM host prefixes', () => {
+      expect(toStageOrigin('https://stage--da-events--adobecom.aem.live'))
+        .to.equal('https://stage--da-events--adobecom.aem.page');
+      expect(toStageOrigin('https://dev--event-libs--adobecom.aem.live'))
+        .to.equal('https://dev--event-libs--adobecom.aem.page');
+    });
+
+    it('should return input unchanged for already-stage origins', () => {
+      expect(toStageOrigin('https://www.stage.adobe.com')).to.equal('https://www.stage.adobe.com');
+      expect(toStageOrigin('https://main--da-events--adobecom.aem.page'))
+        .to.equal('https://main--da-events--adobecom.aem.page');
+    });
+
+    it('should return input unchanged for unknown domains', () => {
+      expect(toStageOrigin('https://example.com')).to.equal('https://example.com');
+      expect(toStageOrigin('https://unknown.domain.org/path')).to.equal('https://unknown.domain.org/path');
+    });
+
+    it('should handle bare hostnames', () => {
+      expect(toStageOrigin('www.adobe.com')).to.equal('www.stage.adobe.com');
+      expect(toStageOrigin('business.adobe.com')).to.equal('business.stage.adobe.com');
+    });
+
+    it('should preserve query parameters and fragments', () => {
+      expect(toStageOrigin('https://www.adobe.com/events?id=123#section'))
+        .to.equal('https://www.stage.adobe.com/events?id=123#section');
+    });
+
+    it('should handle null and empty inputs', () => {
+      expect(toStageOrigin(null)).to.equal(null);
+      expect(toStageOrigin(undefined)).to.equal(undefined);
+      expect(toStageOrigin('')).to.equal('');
+    });
+  });
+
+  describe('toProdOrigin', () => {
+    it('should map www.stage.adobe.com to www.adobe.com', () => {
+      expect(toProdOrigin('https://www.stage.adobe.com')).to.equal('https://www.adobe.com');
+    });
+
+    it('should map www.stage.adobe.com with a path', () => {
+      expect(toProdOrigin('https://www.stage.adobe.com/events/my-event'))
+        .to.equal('https://www.adobe.com/events/my-event');
+    });
+
+    it('should map business.stage.adobe.com to business.adobe.com', () => {
+      expect(toProdOrigin('https://business.stage.adobe.com'))
+        .to.equal('https://business.adobe.com');
+    });
+
+    it('should map .aem.page suffix to .aem.live', () => {
+      expect(toProdOrigin('https://main--da-events--adobecom.aem.page'))
+        .to.equal('https://main--da-events--adobecom.aem.live');
+    });
+
+    it('should map .aem.page with a path', () => {
+      expect(toProdOrigin('https://main--da-events--adobecom.aem.page/events/my-event'))
+        .to.equal('https://main--da-events--adobecom.aem.live/events/my-event');
+    });
+
+    it('should handle various AEM host prefixes', () => {
+      expect(toProdOrigin('https://stage--da-events--adobecom.aem.page'))
+        .to.equal('https://stage--da-events--adobecom.aem.live');
+      expect(toProdOrigin('https://dev--event-libs--adobecom.aem.page'))
+        .to.equal('https://dev--event-libs--adobecom.aem.live');
+    });
+
+    it('should return input unchanged for already-prod origins', () => {
+      expect(toProdOrigin('https://www.adobe.com')).to.equal('https://www.adobe.com');
+      expect(toProdOrigin('https://main--da-events--adobecom.aem.live'))
+        .to.equal('https://main--da-events--adobecom.aem.live');
+    });
+
+    it('should return input unchanged for unknown domains', () => {
+      expect(toProdOrigin('https://example.com')).to.equal('https://example.com');
+    });
+
+    it('should handle bare hostnames', () => {
+      expect(toProdOrigin('www.stage.adobe.com')).to.equal('www.adobe.com');
+      expect(toProdOrigin('business.stage.adobe.com')).to.equal('business.adobe.com');
+    });
+
+    it('should preserve query parameters and fragments', () => {
+      expect(toProdOrigin('https://www.stage.adobe.com/events?id=123#section'))
+        .to.equal('https://www.adobe.com/events?id=123#section');
+    });
+
+    it('should handle null and empty inputs', () => {
+      expect(toProdOrigin(null)).to.equal(null);
+      expect(toProdOrigin(undefined)).to.equal(undefined);
+      expect(toProdOrigin('')).to.equal('');
+    });
+  });
+
+  describe('round-trip consistency', () => {
+    it('should be idempotent for stage origins', () => {
+      const stageUrl = 'https://www.stage.adobe.com/events/page';
+      expect(toStageOrigin(stageUrl)).to.equal(stageUrl);
+    });
+
+    it('should be idempotent for prod origins', () => {
+      const prodUrl = 'https://www.adobe.com/events/page';
+      expect(toProdOrigin(prodUrl)).to.equal(prodUrl);
+    });
+
+    it('should round-trip prod -> stage -> prod', () => {
+      const prodUrl = 'https://www.adobe.com/events/my-event';
+      const stageUrl = toStageOrigin(prodUrl);
+      expect(toProdOrigin(stageUrl)).to.equal(prodUrl);
+    });
+
+    it('should round-trip stage -> prod -> stage', () => {
+      const stageUrl = 'https://www.stage.adobe.com/events/my-event';
+      const prodUrl = toProdOrigin(stageUrl);
+      expect(toStageOrigin(prodUrl)).to.equal(stageUrl);
+    });
+
+    it('should round-trip .aem.live -> .aem.page -> .aem.live', () => {
+      const liveUrl = 'https://main--da-events--adobecom.aem.live/events/page';
+      const pageUrl = toStageOrigin(liveUrl);
+      expect(toProdOrigin(pageUrl)).to.equal(liveUrl);
+    });
+
+    it('should round-trip .aem.page -> .aem.live -> .aem.page', () => {
+      const pageUrl = 'https://main--da-events--adobecom.aem.page/events/page';
+      const liveUrl = toProdOrigin(pageUrl);
+      expect(toStageOrigin(liveUrl)).to.equal(pageUrl);
+    });
+  });
+});


### PR DESCRIPTION
With our content push cycle aligns with standard DA workflow, we should now deprecate the previewMode url param and start using the actual .stage.adobe.com and .aem.page as proper content status flag. This does mean we have to do some sort of origin prediction for the short term, but eventually we should fix the relatedDomain handling for the long term.