### PR TITLE
Add espenv URL param to event preview links

### DIFF
--- a/ecc/blocks/ecc-dashboard/ecc-dashboard.js
+++ b/ecc/blocks/ecc-dashboard/ecc-dashboard.js
@@ -27,7 +27,7 @@ import { initProfileLogicTree } from '../../scripts/profile.js';
 import { cloneFilter, eventObjFilter } from './dashboard-utils.js';
 import { getAttribute, setEventAttribute } from '../../scripts/data-utils.js';
 import { EVENT_TYPES, ENVIRONMENTS } from '../../scripts/constants.js';
-import { getCurrentEnvironment } from '../../scripts/environment.js';
+import { getCurrentEnvironment, getEspEnvParam } from '../../scripts/environment.js';
 
 // API Cache and Throttling System (functional approach)
 const apiCache = (() => {
@@ -438,6 +438,9 @@ function initMoreOptions(props, config, eventObj, row) {
         if (getCurrentEnvironment() !== ENVIRONMENTS.PROD) {
           url = new URL(toStageOrigin(url.href));
         }
+
+        const espEnv = getEspEnvParam();
+        if (espEnv) url.searchParams.set('espenv', espEnv);
 
         return url;
       };

--- a/ecc/blocks/form-handler/form-handler-helper.js
+++ b/ecc/blocks/form-handler/form-handler-helper.js
@@ -35,7 +35,7 @@ import {
   isPublishingLocked,
 } from '../../scripts/utils.js';
 
-import { getCurrentEnvironment } from '../../scripts/environment.js';
+import { getCurrentEnvironment, getEspEnvParam } from '../../scripts/environment.js';
 
 import {
   createEvent,
@@ -1010,16 +1010,21 @@ function updateCtas(props) {
         let previewUrl;
 
         try {
-          previewUrl = new URL(eventDataResp.detailPagePath).href;
+          previewUrl = new URL(eventDataResp.detailPagePath);
         } catch (e) {
-          previewUrl = `${getEventPageHost()}${eventDataResp.detailPagePath}`;
+          previewUrl = new URL(`${getEventPageHost()}${eventDataResp.detailPagePath}`);
         }
 
         if (getCurrentEnvironment() !== ENVIRONMENTS.PROD) {
-          previewUrl = toStageOrigin(previewUrl);
+          previewUrl = new URL(toStageOrigin(previewUrl.href));
         }
 
-        a.href = `${previewUrl}?timing=${testTime}`;
+        previewUrl.searchParams.set('timing', testTime);
+
+        const espEnv = getEspEnvParam();
+        if (espEnv) previewUrl.searchParams.set('espenv', espEnv);
+
+        a.href = previewUrl.toString();
         a.classList.remove('preview-not-ready');
       }
     }

--- a/ecc/scripts/environment.js
+++ b/ecc/scripts/environment.js
@@ -166,6 +166,19 @@ export function getEventServiceHost(relativeDomain, location = window.location) 
  * @returns {string} The event service host URL
  * @throws {Error} If environment detection is not available
  */
+/**
+ * Returns the ESP environment identifier for use as a URL parameter.
+ * Maps LOCAL to DEV (same ESP host). Returns null for PROD (default).
+ * @param {Location} [location=window.location]
+ * @returns {string|null}
+ */
+export function getEspEnvParam(location = window.location) {
+  const env = getCurrentEnvironment(location);
+  if (env === ENVIRONMENTS.PROD) return null;
+  if (env === ENVIRONMENTS.LOCAL) return ENVIRONMENTS.DEV;
+  return env;
+}
+
 export function getDAHost(relativeDomain, location = window.location) {
   const currentEnv = getCurrentEnvironment(location);
   const { hostname, href, origin } = location;


### PR DESCRIPTION
## Summary
- Adds an `espenv` query parameter to all event preview links (pre-event and post-event) on both the dashboard and event creation form, so the event details page knows which ESP backend to call.
- Introduces a shared `getEspEnvParam()` helper in `environment.js` that maps the current environment to the appropriate `espenv` value (`dev`, `dev02`, `stage`, `stage02`), returning `null` for prod.
- Refactors the form-handler preview URL construction from string concatenation to `URL` + `searchParams` for correctness and consistency with the dashboard.

## Test plan
- [ ] On a dev ECC environment, verify preview links include `?espenv=dev`
- [ ] On a stage ECC environment, verify preview links include `?espenv=stage`
- [ ] On prod, verify preview links do **not** include an `espenv` param
- [ ] Verify both pre-event and post-event preview buttons work on the dashboard
- [ ] Verify preview buttons work on the event creation form
- [ ] Verify "Copy URL" on the dashboard is unaffected


Made with [Cursor](https://cursor.com)