### PR TITLE
Add getAllEvents with nextPageToken pagination

### DIFF
--- a/ecc/scripts/esp-controller.js
+++ b/ecc/scripts/esp-controller.js
@@ -975,24 +975,44 @@ export async function deleteEvent(eventId) {
   }
 }
 
-export async function getEvents() {
-  const { host } = API_CONFIG.esp[getCurrentEnvironment()];
-  const options = await constructRequestOptions('GET');
-
-  try {
-    const response = await safeFetch(`${host}/v1/events`, options);
-    const data = await response.json();
-
-    if (!response.ok) {
-      window.lana?.log(`Failed to get list of events. Status: ${response.status}\nError: ${JSON.stringify(data, null, 2)}`);
-      return { status: response.status, error: data };
+async function getAllEvents() {
+  const recurGetEvents = async (fullEventsArr = [], nextPageToken = null) => {
+    const { host } = API_CONFIG.esp[getCurrentEnvironment()];
+    const options = await constructRequestOptions('GET');
+    const baseFetchUrl = `${host}/v1/events`;
+    const potentialUrlParams = new URLSearchParams();
+    if (nextPageToken) {
+      potentialUrlParams.set('next-page-token', nextPageToken);
     }
+    const fetchUrl = `${baseFetchUrl}?${potentialUrlParams.toString()}`;
 
-    return data;
-  } catch (error) {
-    window.lana?.log(`Failed to get list of events:\n${JSON.stringify(error, null, 2)}`);
-    return { status: 'Network Error', error: error.message };
-  }
+    try {
+      const response = await safeFetch(fetchUrl, options);
+      const data = await response.json();
+
+      if (!response.ok) {
+        window.lana?.log(`Failed to get list of events. Status: ${response.status}\nError: ${JSON.stringify(data, null, 2)}`);
+        return { status: response.status, error: data };
+      }
+
+      const allEvents = fullEventsArr.concat(data.events || []);
+
+      if (data.nextPageToken) {
+        return recurGetEvents(allEvents, data.nextPageToken);
+      }
+
+      return { events: allEvents };
+    } catch (error) {
+      window.lana?.log(`Failed to get list of events:\n${JSON.stringify(error, null, 2)}`);
+      return { status: 'Network Error', error: error.message };
+    }
+  };
+
+  return recurGetEvents();
+}
+
+export async function getEvents() {
+  return getAllEvents();
 }
 
 export async function getEventsForUser() {
@@ -1424,7 +1444,7 @@ export async function getAllEventAttendees(eventId) {
       potentialUrlParams.set('type', type);
     }
     if (nextPageToken) {
-      potentialUrlParams.set('nextPageToken', nextPageToken);
+      potentialUrlParams.set('next-page-token', nextPageToken);
     }
     const fetchUrl = `${baseFetchUrl}?${potentialUrlParams.toString()}`;
 


### PR DESCRIPTION
## Summary
Add `getAllEvents` that recursively fetches all events using `next-page-token`, mirroring the pattern used by `getAllEventAttendees`. Refactor `getEvents` to use it so callers always receive exhaustive event lists.

## Changes
- Add `getAllEvents` with recursive helper `recurGetEvents` that exhausts pagination via `next-page-token`
- Refactor `getEvents` to delegate to `getAllEvents` (public API unchanged)
- Fix `getAllEventAttendees`: use `next-page-token` (kebab-case) in URL params

## Call sites (no changes needed)
- `getEventsForUser` and `event-info-component` continue to use `getEvents` and now receive full event lists.

Made with [Cursor](https://cursor.com)