### PR TITLE
MWPW-192736: Add check for milolibs query param

### DIFF
--- a/ecc/scripts/scripts.js
+++ b/ecc/scripts/scripts.js
@@ -208,6 +208,7 @@ export const LIBS = (() => {
   const { hostname, search } = window.location;
   if (!(hostname.includes('.hlx.') || hostname.includes('.aem.') || hostname.includes('local'))) return '/libs';
   const branch = new URLSearchParams(search).get('milolibs') || 'main';
+  if (!/^[a-zA-Z0-9_-]+$/.test(branch)) throw new Error('Invalid branch name.');
   if (branch === 'local') return 'http://localhost:6456/libs';
   return branch.includes('--') ? `https://${branch}.aem.live/libs` : `https://${branch}--milo--adobecom.aem.live/libs`;
 })();


### PR DESCRIPTION
Whitelist branch parameter with `/^[a-zA-Z0-9_-]+$/`; throw on any other characters.

## Ticket
https://jira.corp.adobe.com/browse/MWPW-192736

## Test URLs
Before: https://dev--ecc-milo--adobecom.aem.page/
After: https://MWPW-192736--ecc-milo--zagi25.aem.page/

---
_This PR was generated by Claude (Anthropic's Claude Code CLI)._