### PR TITLE
[MWPW-190192] Enhance schedule maker editor with timezone display and styling updates

### DIFF
--- a/ecc/blocks/schedule-maker/components/editor/BlockEditor.js
+++ b/ecc/blocks/schedule-maker/components/editor/BlockEditor.js
@@ -46,6 +46,21 @@ export default function BlockEditor({ block, editingBlockId, setEditingBlockId }
     return new Date(timestamp).toISOString().slice(0, 16);
   };
 
+  const displayInTimezone = (timestamp, timezone) => {
+    if (!timestamp) return '';
+    return new Intl.DateTimeFormat('en-US', {
+      timeZone: timezone,
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+      timeZoneName: 'short',
+    }).format(new Date(timestamp));
+  };
+
+  const localTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+
   return html`
     <div \
       class="sm-editor__block ${editingBlockId === block.id ? 'sm-editor__block--editing' : ''} ${!block.isComplete ? 'sm-editor__block--incomplete' : ''}" \
@@ -104,35 +119,51 @@ export default function BlockEditor({ block, editingBlockId, setEditingBlockId }
             placeholder="Enter block start date and time" \
           />
         </div>
-        <div class="sm-editor__block-livestream">
-          <sp-checkbox \
-            id="${block.id}-live-stream-checkbox" \
-            name="${block.id}-live-stream-checkbox" \
-            checked=${block.includeLiveStream} \
-            onchange=${(event) => handleLiveStreamChange(block.id, event)} \
-          >
-            Live stream
-          </sp-checkbox>
-          ${block.includeLiveStream && html`
-          <sp-textfield \
-            aria-label="Mobile rider stream id" \
-            type="text" \
-            id="${block.id}-mobile-rider-stream-id-input" \
-            value=${block.liveStream?.streamId || ''} \
-            oninput=${(event) => handleLiveStreamIdChange(block.id, event)} \
-            placeholder="Enter Mobile Rider Stream ID" \
-          />
-          `}
-        </div>
+        ${block.startDateTime && html`
+          <div class="sm-editor__block-datetime-preview">
+            <p class="sm-editor__block-datetime-preview-item">
+              <span class="sm-editor__block-datetime-preview-label">PT:</span>
+              ${displayInTimezone(block.startDateTime, 'America/Los_Angeles')}
+            </p>
+            ${localTimezone !== 'America/Los_Angeles' && html`
+              <p class="sm-editor__block-datetime-preview-item">
+                <span class="sm-editor__block-datetime-preview-label">Local:</span>
+                ${displayInTimezone(block.startDateTime, localTimezone)}
+              </p>
+            `}
+          </div>
+        `}
       </div>
-      <sp-field-label size="l" for="${block.id}-fragment-path-input">Fragment path</sp-field-label>
-      <sp-textfield \
-        type="text" \
-        id="${block.id}-fragment-path-input" \
-        value=${block.fragmentPath} \
-        oninput=${(event) => handleFragmentPathChange(block.id, event)} \
-        placeholder="Enter fragment path" \
-      />
+      <div class="sm-editor__block-livestream">
+        <sp-checkbox \
+          id="${block.id}-live-stream-checkbox" \
+          name="${block.id}-live-stream-checkbox" \
+          checked=${block.includeLiveStream} \
+          onchange=${(event) => handleLiveStreamChange(block.id, event)} \
+        >
+          Live stream
+        </sp-checkbox>
+        ${block.includeLiveStream && html`
+        <sp-textfield \
+          aria-label="Mobile rider stream id" \
+          type="text" \
+          id="${block.id}-mobile-rider-stream-id-input" \
+          value=${block.liveStream?.streamId || ''} \
+          oninput=${(event) => handleLiveStreamIdChange(block.id, event)} \
+          placeholder="Enter Mobile Rider Stream ID" \
+        />
+        `}
+      </div>
+      <div class="sm-editor__block-fragment-path">
+        <sp-field-label size="l" for="${block.id}-fragment-path-input">Fragment path</sp-field-label>
+        <sp-textfield \
+          type="text" \
+          id="${block.id}-fragment-path-input" \
+          value=${block.fragmentPath} \
+          oninput=${(event) => handleFragmentPathChange(block.id, event)} \
+          placeholder="Enter fragment path" \
+        />
+      </div>
     </div>
   `;
 }

--- a/ecc/blocks/schedule-maker/schedule-maker.css
+++ b/ecc/blocks/schedule-maker/schedule-maker.css
@@ -506,16 +506,35 @@
 
 .sm-editor__block-datetime {
   display: flex;
-  align-items: end;
+  align-items: center;
   gap: 21px;
   margin-top: var(--sm-spacing-xs);
   margin-bottom: var(--sm-spacing-md);
+}
+
+.sm-editor__block-datetime-preview {
+  font-size: 12px;
+  color: var(--sm-color-text-secondary, #6e6e6e);
+}
+
+.sm-editor__block-datetime-preview-item {
+  margin: 2px 0;
+}
+
+.sm-editor__block-datetime-preview-label {
+  font-weight: 600;
+  margin-right: 4px;
 }
 
 .sm-editor__block-livestream {
   display: flex;
   align-items: center;
   gap: var(--sm-spacing-md);
+  margin-bottom: var(--sm-spacing-md);
+}
+
+.sm-editor__block-fragment-path {
+  margin-bottom: var(--sm-spacing-md);
 }
 
 .sm-editor__block-incomplete {


### PR DESCRIPTION
- Updated CSS for better alignment and spacing in the datetime block.
- Added functionality to display start date and time in both specified and local timezones.
- Improved layout for livestream options and fragment path input in the editor.

Describe your specific features or fixes and provide a preview link for the feature being incorporated

Resolves: [MWPW-NUMBER](https://jira.corp.adobe.com/browse/MWPW-NUMBER)

Test URLs:
- Before: https://main--ecc-milo--adobecom.aem.live/drafts/
- After: https://stage--ecc-milo--adobecom.aem.live/drafts/

To test the feature, please load up the branch locally and run it against your local ESP and ESL server.
For more information on how to set up ESL and ESP locally, please refer to: [FE Dev Wiki](https://wiki.corp.adobe.com/display/adobedotcom/Events+Milo+FE+Dev+Wiki#EventsMiloFEDevWiki-Localdevelopmentsetup)
