### PR TITLE
MWPW-192519: update copy link text to include modification date

### DIFF
--- a/ecc/blocks/schedule-maker/utils.js
+++ b/ecc/blocks/schedule-maker/utils.js
@@ -172,10 +172,18 @@ class ScheduleURLUtility {
       // Generate the URL using createScheduleURL
       const scheduleURL = this.createScheduleURL(scheduleObject);
 
-      // Extract title and scheduleId from options
-      const { title, scheduleId } = scheduleObject;
-      // Create link text content
-      const linkText = scheduleId ? `Schedule: ${title} (${scheduleId})` : `Schedule: ${title}`;
+      const { title, modificationTime } = scheduleObject;
+      const formattedDate = modificationTime
+        ? new Date(modificationTime).toLocaleString('en-US', {
+          weekday: 'long',
+          month: 'short',
+          day: 'numeric',
+          year: 'numeric',
+          hour: 'numeric',
+          minute: '2-digit',
+        })
+        : '';
+      const linkText = formattedDate ? `Schedule: ${title} – ${formattedDate}` : `Schedule: ${title}`;
 
       // Create a virtual link element
       const linkElement = document.createElement('a');


### PR DESCRIPTION
## Resolves
[MWPW-192519](https://jira.corp.adobe.com/browse/MWPW-192519)

## Summary
Updates the "Copy Link" clipboard text format in the Schedule Maker:

- **Link text** (utils.js): Changed format from `Schedule: <title> (<scheduleId>)` to `Schedule: <title> – <weekday>, <month> <day>, <year> at <time>` using the schedule's `modificationTime`
- **Date formatting**: Uses `toLocaleString` with the browser's local timezone — no timezone pinning

## Testing
- Copy a saved schedule link and paste into a DA document — link text should display the schedule title and last modified date
- Date/time reflects the browser's local timezone

Made with [Claude Code](https://claude.ai/code)
